### PR TITLE
Redirect output from Godot to the Debug console

### DIFF
--- a/rider-godot/src/main/kotlin/com/jetbrains/rider/plugins/godot/run/configurations/GodotDebugProfileState.kt
+++ b/rider-godot/src/main/kotlin/com/jetbrains/rider/plugins/godot/run/configurations/GodotDebugProfileState.kt
@@ -3,9 +3,13 @@ package com.jetbrains.rider.plugins.godot.run.configurations
 import com.intellij.execution.ExecutionResult
 import com.intellij.execution.Executor
 import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.KillableProcessHandler
+import com.intellij.execution.process.ProcessEvent
+import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.ProgramRunner
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.util.Key
 import com.intellij.util.ui.UIUtil
 import com.jetbrains.rd.platform.util.application
 import com.jetbrains.rd.util.lifetime.Lifetime
@@ -13,8 +17,11 @@ import com.jetbrains.rd.util.lifetime.onTermination
 import com.jetbrains.rdclient.util.idea.toIOFile
 import com.jetbrains.rider.debugger.DebuggerHelperHost
 import com.jetbrains.rider.debugger.DebuggerWorkerProcessHandler
+import com.jetbrains.rider.debugger.tryWriteMessageToConsoleView
+import com.jetbrains.rider.model.debuggerWorker.OutputMessageWithSubject
+import com.jetbrains.rider.model.debuggerWorker.OutputSubject
+import com.jetbrains.rider.model.debuggerWorker.OutputType
 import com.jetbrains.rider.plugins.godot.GodotServer
-import com.jetbrains.rider.run.ExternalConsoleMediator
 import com.jetbrains.rider.run.WorkerRunInfo
 import com.jetbrains.rider.run.configurations.remote.MonoConnectRemoteProfileState
 import com.jetbrains.rider.util.NetUtils
@@ -28,25 +35,42 @@ class GodotDebugProfileState(private val remoteConfiguration: GodotDebugRunConfi
     private val project = executionEnvironment.project
 
     override fun execute(executor: Executor, runner: ProgramRunner<*>, workerProcessHandler: DebuggerWorkerProcessHandler, lifetime: Lifetime): ExecutionResult {
+        val path = remoteConfiguration.godotPath
+        val args = mutableListOf(path, "--path", project.basePath.toString())
+        val godotPort = remoteConfiguration.port
+        val commandLine = GeneralCommandLine(args)
+        commandLine.environment.set("GODOT_MONO_DEBUGGER_AGENT", "--debugger-agent=transport=dt_socket,address=127.0.0.1:$godotPort,server=n,suspend=y")
+        commandLine.workDirectory = File(path).parentFile
 
-        application.executeOnPooledThread {
-            val path = remoteConfiguration.godotPath
-            val args = mutableListOf(path, "--path", project.basePath.toString())
-            val godotPort = remoteConfiguration.port
-            val commandLine = GeneralCommandLine(args)
-            commandLine.environment.set("GODOT_MONO_DEBUGGER_AGENT", "--debugger-agent=transport=dt_socket,address=127.0.0.1:$godotPort,server=n,suspend=y")
-            commandLine.workDirectory = File(path).parentFile
+        val godotProcessHandler = KillableProcessHandler(commandLine)
 
-            val processHandler = ExternalConsoleMediator.createProcessHandler(commandLine)
-            processHandler.startNotify()
-
-            lifetime.onTermination {
-                if (!processHandler.isProcessTerminated) {
-                    processHandler.destroyProcess()
-                }
+        lifetime.onTermination {
+            if (!godotProcessHandler.isProcessTerminated) {
+                godotProcessHandler.destroyProcess()
             }
         }
-        return super.execute(executor, runner, workerProcessHandler)
+
+        val monoConnectResult = super.execute(executor, runner, workerProcessHandler)
+
+        godotProcessHandler.addProcessListener(object : ProcessListener {
+            override fun onTextAvailable(p0: ProcessEvent, p1: Key<*>) {
+                monoConnectResult.executionConsole.tryWriteMessageToConsoleView(
+                        OutputMessageWithSubject(p0.text, OutputType.Info, OutputSubject.Default)
+                )
+            }
+
+            override fun processTerminated(p0: ProcessEvent) {}
+            override fun startNotified(p0: ProcessEvent) {}
+        })
+
+        application.executeOnPooledThread {
+            // This is needed to avoid messages from the MonoConnectRemote
+            // run configuration being mixed with the output of Godot Engine.
+            Thread.sleep(2000)
+            godotProcessHandler.startNotify()
+        }
+
+        return monoConnectResult
     }
 
     override fun createWorkerRunCmd(lifetime: Lifetime, helper: DebuggerHelperHost, port: Int): Promise<WorkerRunInfo> {

--- a/rider-godot/src/main/kotlin/com/jetbrains/rider/plugins/godot/run/configurations/GodotDebugProfileState.kt
+++ b/rider-godot/src/main/kotlin/com/jetbrains/rider/plugins/godot/run/configurations/GodotDebugProfileState.kt
@@ -53,14 +53,14 @@ class GodotDebugProfileState(private val remoteConfiguration: GodotDebugRunConfi
         val monoConnectResult = super.execute(executor, runner, workerProcessHandler)
 
         godotProcessHandler.addProcessListener(object : ProcessListener {
-            override fun onTextAvailable(p0: ProcessEvent, p1: Key<*>) {
+            override fun onTextAvailable(processEvent: ProcessEvent, key: Key<*>) {
                 monoConnectResult.executionConsole.tryWriteMessageToConsoleView(
-                        OutputMessageWithSubject(p0.text, OutputType.Info, OutputSubject.Default)
+                        OutputMessageWithSubject(processEvent.text, OutputType.Info, OutputSubject.Default)
                 )
             }
 
-            override fun processTerminated(p0: ProcessEvent) {}
-            override fun startNotified(p0: ProcessEvent) {}
+            override fun processTerminated(processEvent: ProcessEvent) {}
+            override fun startNotified(processEvent: ProcessEvent) {}
         })
 
         application.executeOnPooledThread {
@@ -74,7 +74,6 @@ class GodotDebugProfileState(private val remoteConfiguration: GodotDebugRunConfi
     }
 
     override fun createWorkerRunCmd(lifetime: Lifetime, helper: DebuggerHelperHost, port: Int): Promise<WorkerRunInfo> {
-
         val result = AsyncPromise<WorkerRunInfo>()
         application.executeOnPooledThread {
             try {


### PR DESCRIPTION
No longer create an external console, instead the output of Godot is redirected to the Debug console.

This solution is not perfect, `Input/Output redirection disabled: Debugger is attached to an already running process` is still printed and no input redirection is provided.

Resolves #22.