### PR TITLE
Use a fixed id for the Start and Debug run configuration

### DIFF
--- a/rider-godot/src/main/kotlin/com/jetbrains/rider/plugins/godot/run/configurations/GodotDebugFactory.kt
+++ b/rider-godot/src/main/kotlin/com/jetbrains/rider/plugins/godot/run/configurations/GodotDebugFactory.kt
@@ -10,4 +10,9 @@ open class GodotDebugFactory(type: ConfigurationType)
     override fun createTemplateConfiguration(project: Project) = GodotDebugRunConfiguration(project, this)
     override fun isConfigurationSingletonByDefault() = true
     override fun getIcon() = GodotIcons.RunConfigurations.StartAndDebug
+
+    // This value gets written to the config file. By default it defers to getName, however,
+    // the value needs to be kept the same even if the display name changes in the future
+    // in order to maintain compatibility with older configs.
+    override fun getId() = "Start and Debug"
 }


### PR DESCRIPTION
This removes a DeprecatedMethodException thrown by the default implementation of getId() and solves the reason why it's thrown.

Resolves #18.