### PR TITLE
[WIP] Add actions to debug individual scenes

### DIFF
--- a/rider-godot/src/main/kotlin/com/jetbrains/rider/plugins/godot/ideaInterop/fileTypes/tscn/TscnFile.kt
+++ b/rider-godot/src/main/kotlin/com/jetbrains/rider/plugins/godot/ideaInterop/fileTypes/tscn/TscnFile.kt
@@ -1,0 +1,12 @@
+package com.jetbrains.rider.plugins.godot.ideaInterop.fileTypes.tscn
+
+import com.intellij.lang.Language
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.psi.FileViewProvider
+import com.intellij.psi.impl.source.PsiPlainTextFileImpl
+
+class TscnFile(viewProvider: FileViewProvider) : PsiPlainTextFileImpl(viewProvider) {
+    override fun getFileType(): FileType = TscnFileType
+    override fun toString(): String = "TscnFile:$name"
+    override fun getLanguage(): Language = TscnLanguage
+}

--- a/rider-godot/src/main/kotlin/com/jetbrains/rider/plugins/godot/ideaInterop/fileTypes/tscn/TscnFileType.kt
+++ b/rider-godot/src/main/kotlin/com/jetbrains/rider/plugins/godot/ideaInterop/fileTypes/tscn/TscnFileType.kt
@@ -1,0 +1,11 @@
+package com.jetbrains.rider.plugins.godot.ideaInterop.fileTypes.tscn
+
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.fileTypes.LanguageFileType
+
+object TscnFileType : LanguageFileType(TscnLanguage) {
+    override fun getIcon() = AllIcons.FileTypes.Text
+    override fun getName() = "TSCN"
+    override fun getDefaultExtension() = "tscn"
+    override fun getDescription() = "Text Scene File (Godot)"
+}

--- a/rider-godot/src/main/kotlin/com/jetbrains/rider/plugins/godot/ideaInterop/fileTypes/tscn/TscnLanguage.kt
+++ b/rider-godot/src/main/kotlin/com/jetbrains/rider/plugins/godot/ideaInterop/fileTypes/tscn/TscnLanguage.kt
@@ -1,0 +1,5 @@
+package com.jetbrains.rider.plugins.godot.ideaInterop.fileTypes.tscn
+
+import com.intellij.lang.Language
+
+object TscnLanguage : Language("TSCN")

--- a/rider-godot/src/main/kotlin/com/jetbrains/rider/plugins/godot/ideaInterop/fileTypes/tscn/TscnParserDefinition.kt
+++ b/rider-godot/src/main/kotlin/com/jetbrains/rider/plugins/godot/ideaInterop/fileTypes/tscn/TscnParserDefinition.kt
@@ -1,0 +1,8 @@
+package com.jetbrains.rider.plugins.godot.ideaInterop.fileTypes.tscn
+
+import com.intellij.openapi.fileTypes.PlainTextParserDefinition
+import com.intellij.psi.FileViewProvider
+
+class TscnParserDefinition : PlainTextParserDefinition() {
+    override fun createFile(viewProvider: FileViewProvider) = TscnFile(viewProvider)
+}

--- a/rider-godot/src/main/kotlin/com/jetbrains/rider/plugins/godot/run/configurations/DebugSceneRunConfigurationProducer.kt
+++ b/rider-godot/src/main/kotlin/com/jetbrains/rider/plugins/godot/run/configurations/DebugSceneRunConfigurationProducer.kt
@@ -1,0 +1,37 @@
+package com.jetbrains.rider.plugins.godot.run.configurations
+
+import com.intellij.execution.actions.ConfigurationContext
+import com.intellij.execution.actions.LazyRunConfigurationProducer
+import com.intellij.execution.configurations.runConfigurationType
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.util.Ref
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.psi.PsiElement
+import com.jetbrains.rider.plugins.godot.ideaInterop.fileTypes.tscn.TscnFile
+
+class DebugSceneRunConfigurationProducer : LazyRunConfigurationProducer<GodotDebugRunConfiguration>() {
+    override fun getConfigurationFactory() = runConfigurationType<GodotDebugConfigurationType>().debugFactory
+
+    override fun isConfigurationFromContext(configuration: GodotDebugRunConfiguration, context: ConfigurationContext): Boolean {
+        val sceneName = extractSceneName(context) ?: return false
+        return configuration.godotScene == sceneName
+    }
+
+    override fun setupConfigurationFromContext(configuration: GodotDebugRunConfiguration,
+                                               context: ConfigurationContext,
+                                               sourceElement: Ref<PsiElement>): Boolean {
+        val sceneName = extractSceneName(context) ?: return false
+        configuration.godotScene = sceneName
+        configuration.name = "Scene $sceneName"
+        return true
+    }
+
+    private fun extractSceneName(context: ConfigurationContext): String? {
+        val location = context.psiLocation ?: return null
+        val file = location.containingFile as? TscnFile ?: return null
+        val project = context.project ?: return null
+        val root = ProjectRootManager.getInstance(project).fileIndex.getContentRootForFile(file.virtualFile) ?: return null
+        val filename = FileUtil.getRelativePath(root.path, file.virtualFile.path, '/')
+        return "res://$filename"
+    }
+}

--- a/rider-godot/src/main/kotlin/com/jetbrains/rider/plugins/godot/run/configurations/DebugSceneRunConfigurationProducer.kt
+++ b/rider-godot/src/main/kotlin/com/jetbrains/rider/plugins/godot/run/configurations/DebugSceneRunConfigurationProducer.kt
@@ -20,18 +20,24 @@ class DebugSceneRunConfigurationProducer : LazyRunConfigurationProducer<GodotDeb
     override fun setupConfigurationFromContext(configuration: GodotDebugRunConfiguration,
                                                context: ConfigurationContext,
                                                sourceElement: Ref<PsiElement>): Boolean {
+        val file = getContainingFile(context) ?: return false
         val sceneName = extractSceneName(context) ?: return false
         configuration.godotScene = sceneName
-        configuration.name = "Scene $sceneName"
+        configuration.name = file.name
         return true
     }
 
     private fun extractSceneName(context: ConfigurationContext): String? {
-        val location = context.psiLocation ?: return null
-        val file = location.containingFile as? TscnFile ?: return null
+        val file = getContainingFile(context) ?: return null
         val project = context.project ?: return null
         val root = ProjectRootManager.getInstance(project).fileIndex.getContentRootForFile(file.virtualFile) ?: return null
         val filename = FileUtil.getRelativePath(root.path, file.virtualFile.path, '/')
         return "res://$filename"
+    }
+
+    private fun getContainingFile(context: ConfigurationContext):TscnFile? {
+        val location = context.psiLocation ?: return null
+        val file = location.containingFile as? TscnFile ?: return null
+        return file
     }
 }

--- a/rider-godot/src/main/kotlin/com/jetbrains/rider/plugins/godot/run/configurations/GodotDebugProfileState.kt
+++ b/rider-godot/src/main/kotlin/com/jetbrains/rider/plugins/godot/run/configurations/GodotDebugProfileState.kt
@@ -38,6 +38,9 @@ class GodotDebugProfileState(private val remoteConfiguration: GodotDebugRunConfi
         val path = remoteConfiguration.godotPath
         val args = mutableListOf(path, "--path", project.basePath.toString())
         val godotPort = remoteConfiguration.port
+        val scene = remoteConfiguration.godotScene
+        if (scene != null)
+            args.add(scene)
         val commandLine = GeneralCommandLine(args)
         commandLine.environment.set("GODOT_MONO_DEBUGGER_AGENT", "--debugger-agent=transport=dt_socket,address=127.0.0.1:$godotPort,server=n,suspend=y")
         commandLine.workDirectory = File(path).parentFile

--- a/rider-godot/src/main/kotlin/com/jetbrains/rider/plugins/godot/run/configurations/GodotDebugRunConfiguration.kt
+++ b/rider-godot/src/main/kotlin/com/jetbrains/rider/plugins/godot/run/configurations/GodotDebugRunConfiguration.kt
@@ -20,6 +20,7 @@ class GodotDebugRunConfiguration(project: Project, factory: ConfigurationFactory
     @Transient override var port: Int = -1
     @Transient override var address: String = "127.0.0.1"
     @Transient var godotPath: String = ""
+    var godotScene: String? = null
 
     override fun hideDisabledExecutorButtons(): Boolean {
         return true

--- a/rider-godot/src/main/resources/META-INF/plugin.xml
+++ b/rider-godot/src/main/resources/META-INF/plugin.xml
@@ -10,6 +10,16 @@
 
   <extensions defaultExtensionNs="com.intellij">
     <configurationType implementation="com.jetbrains.rider.plugins.godot.run.configurations.GodotDebugConfigurationType" />
+
+    <!-- TSCN support -->
+    <fileType name="TSCN"
+              language="TSCN"
+              fieldName="INSTANCE"
+              implementationClass="com.jetbrains.rider.plugins.godot.ideaInterop.fileTypes.tscn.TscnFileType"
+              extensions="tscn" />
+    <lang.parserDefinition language="TSCN" implementationClass="com.jetbrains.rider.plugins.godot.ideaInterop.fileTypes.tscn.TscnParserDefinition" />
+
+    <runConfigurationProducer implementation="com.jetbrains.rider.plugins.godot.run.configurations.DebugSceneRunConfigurationProducer" />
   </extensions>
 
   <project-components>


### PR DESCRIPTION
Adds a right-click action to start and debug individual scenes to .tscn files.

Currently also adds an action to run the configuration with Profiling, but trying to use it throws an error as it's not supported by the run configuration.

Resolves #2.