### PR TITLE
Support changes in Godot 4 related to NET6 adoption

### DIFF
--- a/resharper/src/UnitTesting/GodotCoreTestRunnerHost.cs
+++ b/resharper/src/UnitTesting/GodotCoreTestRunnerHost.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using JetBrains.Annotations;
+using JetBrains.Collections.Viewable;
+using JetBrains.RdBackend.Common.Features;
+using JetBrains.ReSharper.UnitTestFramework.Execution.TestRunner;
+using JetBrains.Rider.Model.Godot.FrontendBackend;
+using JetBrains.Util;
+
+namespace JetBrains.ReSharper.Plugins.Godot.UnitTesting
+{
+    public class GodotCoreTestRunnerHost : DefaultTestRunnerHost
+    {
+        [NotNull] public new static readonly ITestRunnerHost Instance = new GodotCoreTestRunnerHost();
+        private const string pluginDirectory = "RiderTestRunner";
+        private const string runnerScene = "NetCoreRunner.tscn";
+
+        public override IPreparedProcess StartProcess(ProcessStartInfo startInfo, ITestRunnerContext context)
+        {
+            var solution = context.RuntimeEnvironment.Project.GetSolution();
+            var solutionDirectory = solution.SolutionDirectory;
+            var scenePaths = solutionDirectory.GetChildDirectories(pluginDirectory,
+                PathSearchFlags.ExcludeFiles | PathSearchFlags.RecurseIntoSubdirectories).Select(a=>a.Combine(runnerScene)).Where(a => a.ExistsFile).ToArray();
+            if (!scenePaths.Any())
+                throw new Exception("Please manually put folder with files from https://github.com/van800/godot-demo-projects/tree/net6/mono/dodge_the_creeps/RiderTestRunner to your project.");
+            if (scenePaths.Length > 1)
+                throw new Exception($"Make sure you have only 1 {pluginDirectory}/{runnerScene} in your project.");
+            
+            var args = CommandLineUtil.ToArray(startInfo.Arguments);
+            var fileName = args[8];
+            
+            var usefulArgs = CommandLineUtil.ToString(args.Skip(9));
+
+            var solutionDir = solution.SolutionDirectory;
+            var model = solution.GetProtocolSolution().GetGodotFrontendBackendModel();
+
+            if (model == null)
+                throw new InvalidOperationException("Missing connection to frontend.");
+            if (!model.GodotPath.HasValue())
+                throw new InvalidOperationException("GodotPath is unknown.");
+            var godotPath = model.GodotPath.Value;
+
+            var sceneRelPath = scenePaths.Single().MakeRelativeTo(solutionDirectory);
+            startInfo.FileName = godotPath;
+            startInfo.Arguments =
+                $"--path \"{solutionDir}\" \"res://{sceneRelPath}\" --unit_test_assembly \"{fileName}\" --unit_test_args \"{usefulArgs}\"";
+
+
+            if (context is ITestRunnerExecutionContext executionContext)
+            {
+                return executionContext.Run.HostController.StartProcess(startInfo, executionContext.Run, context.Logger);
+            }
+
+            return base.StartProcess(startInfo, context);
+        }
+
+        public override IEnumerable<Assembly> InProcessAssemblies => EmptyArray<Assembly>.Instance;
+
+    }
+}

--- a/resharper/src/UnitTesting/GodotRiderProcessStartInfoPatcher.cs
+++ b/resharper/src/UnitTesting/GodotRiderProcessStartInfoPatcher.cs
@@ -11,17 +11,18 @@ namespace JetBrains.ReSharper.Plugins.Godot.UnitTesting
     [SolutionInstanceComponent]
     public class GodotRiderProcessStartInfoPatcher : RiderProcessStartInfoPatcher
     {
-        private readonly ISolution mySolution;
+        private IViewableProperty<bool> MyIsNet6Property;
+        private IViewableProperty<string> myGodotPathProperty;
 
         public GodotRiderProcessStartInfoPatcher(ILogger logger, ISolutionToolset solutionToolset, RiderProcessStartInfoEnvironment environment, ISolution solution) : base(logger, solutionToolset, environment)
         {
-            mySolution = solution;
+            MyIsNet6Property = solution.GetProtocolSolution().GetGodotFrontendBackendModel().IsNet6Plus;
+            myGodotPathProperty = solution.GetProtocolSolution().GetGodotFrontendBackendModel().GodotPath;
         }
 
         public override ProcessStartInfoPatchResult Patch(JetProcessStartInfo info, JetProcessRuntimeRequest request)
         {
-            if (mySolution.GetProtocolSolution().GetGodotFrontendBackendModel().IsNet6Plus.HasTrueValue()
-                && mySolution.GetProtocolSolution().GetGodotFrontendBackendModel().GodotPath.Value == info.FileName)
+            if (MyIsNet6Property.HasTrueValue() && myGodotPathProperty.Value == info.FileName)
                 return base.Patch(new JetProcessStartInfo(info.FileName, info.Arguments, info.WorkingDirectory, info.ToProcessStartInfo().Environment), 
                     JetProcessRuntimeRequest.CreateDirect(request.EnvironmentVariableMutator));
             return base.Patch(info, request);

--- a/resharper/src/UnitTesting/GodotRiderProcessStartInfoPatcher.cs
+++ b/resharper/src/UnitTesting/GodotRiderProcessStartInfoPatcher.cs
@@ -1,0 +1,31 @@
+using JetBrains.Application.Processes;
+using JetBrains.Collections.Viewable;
+using JetBrains.ProjectModel;
+using JetBrains.RdBackend.Common.Features;
+using JetBrains.RdBackend.Common.Features.Processes;
+using JetBrains.Rider.Model.Godot.FrontendBackend;
+using JetBrains.Util;
+
+namespace JetBrains.ReSharper.Plugins.Godot.UnitTesting
+{
+    [SolutionInstanceComponent]
+    public class GodotRiderProcessStartInfoPatcher : RiderProcessStartInfoPatcher
+    {
+        private readonly ISolution mySolution;
+
+        public GodotRiderProcessStartInfoPatcher(ILogger logger, ISolutionToolset solutionToolset, RiderProcessStartInfoEnvironment environment, ISolution solution) : base(logger, solutionToolset, environment)
+        {
+            mySolution = solution;
+        }
+
+        public override ProcessStartInfoPatchResult Patch(JetProcessStartInfo info, JetProcessRuntimeRequest request)
+        {
+            if (mySolution.GetProtocolSolution().GetGodotFrontendBackendModel().IsNet6Plus.HasTrueValue()
+                && mySolution.GetProtocolSolution().GetGodotFrontendBackendModel().GodotPath.Value == info.FileName)
+                return base.Patch(new JetProcessStartInfo(info.FileName, info.Arguments, info.WorkingDirectory, info.ToProcessStartInfo().Environment), 
+                    JetProcessRuntimeRequest.CreateDirect(request.EnvironmentVariableMutator));
+            return base.Patch(info, request);
+        }
+        
+    }
+}

--- a/resharper/src/UnitTesting/GodotTestRunnerHost.cs
+++ b/resharper/src/UnitTesting/GodotTestRunnerHost.cs
@@ -134,16 +134,16 @@ namespace JetBrains.ReSharper.Plugins.Godot.UnitTesting
                 var fileName = startInfo.FileName;
                 var args = startInfo.Arguments;
 
-                var solutionDir = mySolution.SolutionDirectory.QuoteIfNeeded();
+                var solutionDir = mySolution.SolutionDirectory;
 
                 if (myModel == null)
                     throw new InvalidOperationException("Missing connection to frontend.");
                 if (!myModel.GodotPath.HasValue())
                     throw new InvalidOperationException("GodotPath is unknown.");
-                var godotPath = myModel.GodotPath.Value.QuoteIfNeeded();
+                var godotPath = myModel.GodotPath.Value;
                 
                 var patchedInfo = startInfo.Patch(godotPath,
-                    $"--path {solutionDir} \"res://{mySceneRelPath}\" --unit_test_assembly \"{fileName}\" --unit_test_args \"{args}\"",
+                    $"--path \"{solutionDir}\" \"res://{mySceneRelPath}\" --unit_test_assembly \"{fileName}\" --unit_test_args \"{args}\"",
                     EnvironmentVariableMutator.Empty);
 
                 return ProcessStartInfoPatchResult.CreateSuccess(startInfo, request, patchedInfo);

--- a/resharper/src/UnitTesting/GodotTestRunnerHostProvider.cs
+++ b/resharper/src/UnitTesting/GodotTestRunnerHostProvider.cs
@@ -1,3 +1,4 @@
+using JetBrains.Collections.Viewable;
 using JetBrains.ProjectModel;
 using JetBrains.RdBackend.Common.Features;
 using JetBrains.ReSharper.Plugins.Godot.ProjectModel;
@@ -17,6 +18,7 @@ namespace JetBrains.ReSharper.Plugins.Godot.UnitTesting
         
         public ITestRunnerHost TryGetHost(IProject project, TargetFrameworkId targetFrameworkId)
         {
+            if (project.IsGodotProject() && project.GetSolution().GetProtocolSolution().GetGodotFrontendBackendModel().IsNet6Plus.HasTrueValue()) return GodotCoreTestRunnerHost.Instance;
             return project.IsGodotProject() ? GodotTestRunnerHost.Instance : null;
         }
     }

--- a/resharper/src/UnitTesting/ZoneMarker.cs
+++ b/resharper/src/UnitTesting/ZoneMarker.cs
@@ -1,10 +1,11 @@
 using JetBrains.Application.BuildScript.Application.Zones;
+using JetBrains.RdBackend.Common.Env;
 using JetBrains.ReSharper.UnitTestFramework;
 
 namespace JetBrains.ReSharper.Plugins.Godot.UnitTesting
 {
     [ZoneMarker]
-    public class ZoneMarker : IRequire<IUnitTestingZone>
+    public class ZoneMarker : IRequire<IUnitTestingZone>, IRequire<IResharperHostCoreFeatureZone>
     {
     }
 }

--- a/rider/build.gradle.kts
+++ b/rider/build.gradle.kts
@@ -11,10 +11,10 @@ repositories {
 }
 
 plugins {
-    id("org.jetbrains.intellij") version "1.8.0" // https://github.com/JetBrains/gradle-intellij-plugin/releases
+    id("org.jetbrains.intellij") version "1.9.0" // https://github.com/JetBrains/gradle-intellij-plugin/releases
     id("org.jetbrains.grammarkit") version "2021.2.2"
     id("me.filippov.gradle.jvm.wrapper") version "0.11.0"
-    id("com.jetbrains.rdgen") version "2022.3.1"
+    id("com.jetbrains.rdgen") version "2022.3.2"
     kotlin("jvm") version "1.7.0"
 }
 

--- a/rider/protocol/src/kotlin/model/frontendBackend/GodotFrontendBackendModel.kt
+++ b/rider/protocol/src/kotlin/model/frontendBackend/GodotFrontendBackendModel.kt
@@ -29,6 +29,7 @@ object GodotFrontendBackendModel : Ext(SolutionModel.Solution) {
 
         // Misc backend/fronted context
         property("godotPath", string).documentation = "Path to GodotEditor"
+        property("isNet6Plus", bool).documentation = "Is net6+"
 
         // Settings stored in the backend
         field("backendSettings", aggregatedef("GodotBackendSettings") {

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/godot/FrontendBackendHost.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/godot/FrontendBackendHost.kt
@@ -11,7 +11,6 @@ import com.intellij.util.BitUtil
 import com.jetbrains.rd.framework.impl.RdTask
 import com.jetbrains.rd.platform.util.idea.ProtocolSubscribedProjectComponent
 import com.jetbrains.rd.util.firstOrNull
-import com.jetbrains.rd.util.lifetime.onTermination
 import com.jetbrains.rd.util.reactive.*
 import com.jetbrains.rider.debugger.DebuggerInitializingState
 import com.jetbrains.rider.debugger.DotNetDebugProcess
@@ -90,8 +89,13 @@ class FrontendBackendHost(project: Project) : ProtocolSubscribedProjectComponent
             task
         }
 
-        GodotProjectDiscoverer.getInstance(project).godotPath.adviseNotNull(projectComponentLifetime){
+        GodotProjectDiscoverer.getInstance(project).godotMonoPath.adviseNotNull(projectComponentLifetime){
             model.godotPath.set(it)
+        }
+
+        GodotProjectDiscoverer.getInstance(project).godotCorePath.adviseNotNull(projectComponentLifetime){
+            model.godotPath.set(it)
+            model.isNet6Plus.set(true)
         }
     }
 

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/godot/GodotProjectDiscoverer.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/godot/GodotProjectDiscoverer.kt
@@ -20,7 +20,8 @@ class GodotProjectDiscoverer(project: Project) : LifetimedService() {
     private val projectGodotPath = Paths.get(project.basePath!!).resolve("project.godot")
     val isGodotProject: IProperty<Boolean> = Property(false)
     val hasWATAddon: IProperty<Boolean> = Property(false)
-    val godotPath : IProperty<String?> = Property(null)
+    val godotMonoPath : IProperty<String?> = Property(null)
+    val godotCorePath : IProperty<String?> = Property(null)
 
     init {
         val isGodot = getIsGodotProject(project)
@@ -30,7 +31,8 @@ class GodotProjectDiscoverer(project: Project) : LifetimedService() {
                         hasWATAddon.set(Paths.get(project.basePath!!).resolve("addons/WAT/gui.tscn").exists())
 
             isGodotProject.set(isGodot)
-            godotPath.set(MetadataFileWatcher.getFromMonoMetadataPath(project) ?: MetadataFileWatcher.getGodotPath(project) ?: getGodotPathFromPlayerRunConfiguration(project))
+            godotMonoPath.set(MetadataMonoFileWatcher.getFromMonoMetadataPath(project) ?: MetadataMonoFileWatcher.getGodotPath(project) ?: getGodotPathFromPlayerRunConfiguration(project))
+            godotCorePath.set(MetadataCoreFileWatcher.getGodotPath(project))
         }
     }
 

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/godot/MetadataCoreFileWatcher.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/godot/MetadataCoreFileWatcher.kt
@@ -1,0 +1,83 @@
+package com.jetbrains.rider.plugins.godot
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import com.intellij.util.application
+import com.intellij.util.io.exists
+import com.intellij.util.io.isDirectory
+import com.jetbrains.rd.util.lifetime.isAlive
+import com.jetbrains.rd.util.reactive.whenTrue
+import com.jetbrains.rdclient.util.idea.LifetimedProjectComponent
+import com.jetbrains.rider.projectView.solution
+import com.jetbrains.rider.projectView.solutionDirectory
+import java.nio.file.*
+import java.nio.file.StandardWatchEventKinds.ENTRY_CREATE
+import java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY
+import kotlin.concurrent.thread
+
+
+class MetadataCoreFileWatcher(project: Project) : LifetimedProjectComponent(project) {
+
+    companion object {
+        const val cfgDir = ".godot/editor"
+        const val cfgFileName = "project_metadata.cfg"
+        private val logger = Logger.getInstance(MetadataCoreFileWatcher::class.java)
+
+        fun getGodotPath(project:Project):String? {
+            val projectPath = project.solutionDirectory
+            val projectMetadataCfg = projectPath.resolve(cfgDir).resolve(cfgFileName)
+
+            if (projectMetadataCfg.exists()){
+                val line = projectMetadataCfg.readLines().singleOrNull { it.startsWith("executable_path=") }
+                if (line != null)
+                {
+                    val path = line.substring("executable_path=\"".length, line.trimEnd().length - 1)
+                    if (Paths.get(path).exists())
+                        return path
+                }
+            }
+            return null
+        }
+    }
+
+    init {
+        project.solution.isLoaded.whenTrue(componentLifetime) {l->
+            val godotDiscoverer = GodotProjectDiscoverer.getInstance(project)
+            godotDiscoverer.isGodotProject.whenTrue(l) { lt ->
+                thread(name = "MetadataFileWatcher") {
+                    val watchService: WatchService = FileSystems.getDefault().newWatchService()
+                    val metaFileDir = project.solutionDirectory.resolve(cfgDir).toPath()
+
+                    if (!(metaFileDir.isDirectory()))
+                        return@thread
+
+                    metaFileDir.register(watchService, ENTRY_CREATE, ENTRY_MODIFY)
+
+                    lt.onTerminationIfAlive {
+                        watchService.close() // releases watchService.take()
+                    }
+
+                    var key: WatchKey
+                    try {
+                        while (watchService.take().also { key = it } != null && lt.isAlive) {
+                            for (event in key.pollEvents()) {
+                                val context = event.context() ?: continue
+                                if (context.toString() == cfgFileName) {
+                                    logger.info("GodotCoreProjectDiscoverer.getInstance(project).godotPath.set()")
+                                    val newPath = getGodotPath(project) ?: continue
+                                    logger.info("GodotCoreProjectDiscoverer.getInstance(project).godotPath.set($newPath)")
+                                    application.invokeLater {
+                                        logger.info("application.invokeLater GodotProjectDiscoverer.getInstance(project).godotPath.set($newPath)")
+                                        GodotProjectDiscoverer.getInstance(project).godotCorePath.set(newPath)
+                                    }
+                                }
+                            }
+                            key.reset()
+                        }
+                    } catch (e: ClosedWatchServiceException) {
+                    } // this is expected on `watchService.close()`
+                }
+            }
+        }
+    }
+}

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/godot/MetadataMonoFileWatcher.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/godot/MetadataMonoFileWatcher.kt
@@ -20,13 +20,13 @@ import kotlin.concurrent.thread
 import kotlin.io.path.readLines
 
 
-class MetadataFileWatcher(project: Project) : LifetimedProjectComponent(project) {
+class MetadataMonoFileWatcher(project: Project) : LifetimedProjectComponent(project) {
 
     companion object {
         const val metaFileDir = ".mono/metadata"
         const val metaFileName = "ide_messaging_meta.txt"
         const val oldMetaFileName = "ide_server_meta.txt"
-        private val logger = Logger.getInstance(MetadataFileWatcher::class.java)
+        private val logger = Logger.getInstance(MetadataMonoFileWatcher::class.java)
 
         // https://github.com/godotengine/godot-proposals/issues/555#issuecomment-595242973
         //Windows: %APPDATA%\Godot\projects\{PROJECT_NAME}_{MD5_OF_PROJECT_PATH}\
@@ -116,7 +116,7 @@ class MetadataFileWatcher(project: Project) : LifetimedProjectComponent(project)
                                     logger.info("GodotProjectDiscoverer.getInstance(project).godotPath.set($newPath)")
                                     application.invokeLater {
                                         logger.info("application.invokeLater GodotProjectDiscoverer.getInstance(project).godotPath.set($newPath)")
-                                        GodotProjectDiscoverer.getInstance(project).godotPath.set(newPath)
+                                        GodotProjectDiscoverer.getInstance(project).godotMonoPath.set(newPath)
                                     }
                                 }
                             }

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/godot/run/GodotRunConfigurationGenerator.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/godot/run/GodotRunConfigurationGenerator.kt
@@ -11,8 +11,11 @@ import com.jetbrains.rider.plugins.godot.GodotProjectDiscoverer
 import com.jetbrains.rider.plugins.godot.run.configurations.GodotDebugRunConfiguration
 import com.jetbrains.rider.plugins.godot.run.configurations.GodotDebugRunConfigurationType
 import com.jetbrains.rider.projectView.solution
+import com.jetbrains.rider.run.configurations.dotNetExe.DotNetExeConfiguration
+import com.jetbrains.rider.run.configurations.dotNetExe.DotNetExeConfigurationType
 import com.jetbrains.rider.run.configurations.remote.DotNetRemoteConfiguration
 import com.jetbrains.rider.run.configurations.remote.MonoRemoteConfigType
+import com.jetbrains.rider.runtime.dotNetCore.DotNetCoreRuntimeType
 
 class GodotRunConfigurationGenerator(project: Project) : LifetimedProjectComponent(project) {
 
@@ -33,21 +36,39 @@ class GodotRunConfigurationGenerator(project: Project) : LifetimedProjectCompone
                 logger.info("isGodotProject = true")
                 val runManager = RunManager.getInstance(project)
 
-                // Add configuration, if it doesn't exist
-                if (!runManager.allSettings.any { it.type is MonoRemoteConfigType && it.name == ATTACH_CONFIGURATION_NAME }) {
-                    val configurationType = ConfigurationTypeUtil.findConfigurationType(MonoRemoteConfigType::class.java)
-                    val runConfiguration = runManager.createConfiguration(ATTACH_CONFIGURATION_NAME, configurationType.factory)
-                    val remoteConfig = runConfiguration.configuration as DotNetRemoteConfiguration
-                    remoteConfig.port = godotDiscoverer.port
-                    runConfiguration.storeInLocalWorkspace()
-                    runManager.addConfiguration(runConfiguration)
+                GodotProjectDiscoverer.getInstance(project).godotCorePath.advise(lt) { corePath->
+                    if (corePath != null) {
+                        val toRemove = runManager.allSettings.filter {
+                            it.type is MonoRemoteConfigType && it.name == ATTACH_CONFIGURATION_NAME
+                        }
+                        for (value in toRemove) {
+                            runManager.removeConfiguration(value)
+                        }
+                    }
+                    else{
+                        if (!runManager.allSettings.any { it.type is MonoRemoteConfigType && it.name == ATTACH_CONFIGURATION_NAME }) {
+                            val configurationType = ConfigurationTypeUtil.findConfigurationType(MonoRemoteConfigType::class.java)
+                            val runConfiguration = runManager.createConfiguration(ATTACH_CONFIGURATION_NAME, configurationType.factory)
+                            val remoteConfig = runConfiguration.configuration as DotNetRemoteConfiguration
+                            remoteConfig.port = godotDiscoverer.port
+                            runConfiguration.storeInLocalWorkspace()
+                            runManager.addConfiguration(runConfiguration)
+                        }
+                    }
                 }
 
-                GodotProjectDiscoverer.getInstance(project).godotPath.adviseNotNull(lt){ path ->
+                GodotProjectDiscoverer.getInstance(project).godotMonoPath.adviseNotNull(lt){ path ->
                     createOrUpdateRunConfiguration(PLAYER_CONFIGURATION_NAME, "--path \"${project.basePath}\"", runManager, path, project)
                     createOrUpdateRunConfiguration(EDITOR_CONFIGURATION_NAME, "--path \"${project.basePath}\" --editor", runManager, path, project)
                     if (godotDiscoverer.hasWATAddon.value)
                         createOrUpdateRunConfiguration(WAT_UNIT_TESTING, "--path \"${project.basePath}\" \"res://addons/WAT/gui.tscn\"", runManager, path, project)
+                }
+
+                GodotProjectDiscoverer.getInstance(project).godotCorePath.adviseNotNull(lt){ path ->
+                    createOrUpdateCoreRunConfiguration(PLAYER_CONFIGURATION_NAME, "--path \"${project.basePath}\"", runManager, path, project)
+                    createOrUpdateCoreRunConfiguration(EDITOR_CONFIGURATION_NAME, "--path \"${project.basePath}\" --editor", runManager, path, project)
+                    if (godotDiscoverer.hasWATAddon.value)
+                        createOrUpdateCoreRunConfiguration(WAT_UNIT_TESTING, "--path \"${project.basePath}\" \"res://addons/WAT/gui.tscn\"", runManager, path, project)
                 }
 
                 // make configuration selected if nothing is selected
@@ -58,6 +79,31 @@ class GodotRunConfigurationGenerator(project: Project) : LifetimedProjectCompone
                     }
                 }
             }
+        }
+    }
+
+    private fun createOrUpdateCoreRunConfiguration(
+        configurationName: String,
+        programParameters:String,
+        runManager: RunManager,
+        godotPath: String,
+        project: Project
+    ) {
+        val configs = runManager.allSettings.filter { it.type is DotNetExeConfiguration && it.name == configurationName }
+        if (configs.any()) {
+            configs.forEach{
+                (it.configuration as DotNetExeConfiguration).parameters.exePath = godotPath
+            }
+        } else {
+            val configurationType = ConfigurationTypeUtil.findConfigurationType(DotNetExeConfigurationType::class.java)
+            val runConfiguration = runManager.createConfiguration(configurationName, configurationType.factory)
+            val config = runConfiguration.configuration as DotNetExeConfiguration
+            config.parameters.exePath = godotPath
+            config.parameters.programParameters = programParameters
+            config.parameters.workingDirectory = "${project.basePath}"
+            config.parameters.runtimeType = DotNetCoreRuntimeType
+            runConfiguration.storeInLocalWorkspace()
+            runManager.addConfiguration(runConfiguration)
         }
     }
 

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/godot/run/configurations/DebugSceneRunConfigurationProducer.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/godot/run/configurations/DebugSceneRunConfigurationProducer.kt
@@ -27,7 +27,10 @@ class DebugSceneRunConfigurationProducer : LazyRunConfigurationProducer<GodotDeb
         val file = getContainingFile(context) ?: return false
         val resPath = extractResPath(context) ?: return false
 
-        val path = GodotProjectDiscoverer.getInstance(context.project).godotPath.value
+        var path = GodotProjectDiscoverer.getInstance(context.project).godotCorePath.value
+        if (path == null)
+            path = GodotProjectDiscoverer.getInstance(context.project).godotMonoPath.value
+
         if (path == null || !File(path).exists()) {
             return false
         }

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/godot/run/configurations/GodotDebugRunConfiguration.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/godot/run/configurations/GodotDebugRunConfiguration.kt
@@ -8,6 +8,7 @@ import com.intellij.execution.configurations.RunProfileState
 import com.intellij.execution.executors.DefaultDebugExecutor
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.project.Project
+import com.jetbrains.rider.plugins.godot.GodotProjectDiscoverer
 import com.jetbrains.rider.run.configurations.exe.ExeConfiguration
 import com.jetbrains.rider.run.configurations.exe.ExeConfigurationParameters
 import com.jetbrains.rider.run.configurations.remote.DotNetRemoteConfiguration
@@ -30,7 +31,7 @@ class GodotDebugRunConfiguration(name:String, project: Project, factory: Configu
     override fun getState(executor: Executor, environment: ExecutionEnvironment): RunProfileState{
         val executorId = executor.id
 
-        if (executorId == DefaultDebugExecutor.EXECUTOR_ID)
+        if (executorId == DefaultDebugExecutor.EXECUTOR_ID && GodotProjectDiscoverer.getInstance(project).godotCorePath.value == null)
             return GodotDebugProfileState(this, DotNetRemoteConfiguration(project, ConfigurationTypeUtil.findConfigurationType(MonoRemoteConfigType::class.java).factory, name), environment)
 
         return super.getState(executor, environment)

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin url="https://github.com/JetBrains/godot-support">
   <id>com.intellij.rider.godot</id>
   <name>Godot Support</name>
-  <version>2023.2.0.9999</version>
+  <version>2022.3.0.9999</version>
   <vendor url="https://www.jetbrains.com">JetBrains</vendor>
 
   <idea-version since-build="223.0.0" until-build="224.0.0" />
@@ -16,7 +16,8 @@
   <project-components>
     <component><implementation-class>com.jetbrains.rider.plugins.godot.run.GodotRunConfigurationGenerator</implementation-class></component>
     <component><implementation-class>com.jetbrains.rider.plugins.godot.FrontendBackendHost</implementation-class></component>
-    <component><implementation-class>com.jetbrains.rider.plugins.godot.MetadataFileWatcher</implementation-class></component>
+    <component><implementation-class>com.jetbrains.rider.plugins.godot.MetadataMonoFileWatcher</implementation-class></component>
+    <component><implementation-class>com.jetbrains.rider.plugins.godot.MetadataCoreFileWatcher</implementation-class></component>
   </project-components>
 
   <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
- Run and Debug Player and Editor stays nearly the same
- Attach disappear and can be done via Run->Attach to Process
- UnitTesting support requires manual update of the Runner into [NetCoreRunner](https://github.com/van800/godot-demo-projects/tree/net6/mono/dodge_the_creeps/RiderTestRunner)
- [WIP] For Rider 2022.3 (next version): Proper UnitTesting support requires a change in Rider itself to avoid [hack](https://github.com/JetBrains/godot-support/pull/80/files#diff-052f70960c74bd82c85651731b800d5aac98ad66f7a9c8d2f1d2da7615e6ff91R23-R26)
