### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
  
 # Godot Support for Rider
 
-The "Godot Support" plugin adds specific functionality for the [Godot game engine](https://godotengine.org/) Mono version (C# support) to [Rider](https://www.jetbrains.com/rider/).
+The "Godot Support" plugin adds specific functionality for the [Godot game engine](https://godotengine.org/) .NET version (C# support) to [Rider](https://www.jetbrains.com/rider/).
 
 Rider is JetBrains' cross platform .NET IDE, based on ReSharper and the IntelliJ Platform. It can be used on Windows, Mac and Linux providing rich code navigation, inspections and refactorings.
 


### PR DESCRIPTION
Godot 4 uses .NET 6 and not Mono anymore.