### PR TITLE
mark incompatible-with exigow gdscript, since it is obsolete

### DIFF
--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -3,6 +3,7 @@
   <name>Godot Support</name>
   <version>2024.1.0.9999</version>
   <vendor url="https://www.jetbrains.com">JetBrains</vendor>
+  <incompatible-with>gdscript</incompatible-with> <!-- Obsolete https://github.com/exigow/intellij-gdscript.git -->
 
   <idea-version since-build="241.11761" until-build="242.*" />
 


### PR DESCRIPTION
Opening gd file would only suggest IceExplosive/gdscript
And the exigow/intellij-gdscript would be ignored