### PR TITLE
Explicitly mention Godot versions supported

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,8 @@ Debugger extension. Adds “Current Scene” item to the Variables and Watches t
 
 Godot specific warnings and quick fixes. A warning and a quick-fix for a missing parameterless ctor. [Pull request](https://github.com/JetBrains/godot-support/pull/127)
 
+Works with Godot version 3.x and 4.x.
+
 # Recomendations
 
 Add `.idea` to [.gitignore](https://github.com/van800/godot-demo-projects/pull/2/files#diff-a084b794bc0759e7a6b77810e01874f2R22) 


### PR DESCRIPTION
I know this seems like a silly PR, but I'm evaluating using Rider for Godot 3.5 and I can't find any info in the github project or the plugin page itself on which versions are supported. After 20 minutes of looking around I'm still not sure to be honest.

So if 3.x and 4.x are both supported, I think it should be mentioned explicitly at least in the README (and probably on the plugin page as well) so that other people can find this information quickly instead of having to ask, assume, or install and try.

And if they're not both supported, at least this PR will serve as explicit confirmation on the answer. 🙂