### PR TITLE
Rename 'brakepoints' to 'breakpoints' for consistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,13 @@ jobs:
               working-directory: rider
               run: ./gradlew -PBuildConfiguration=Release -PbuildNumber=${{ github.run_number }} test
             - name: Upload Test Results
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v4
               with:
                   name: ${{ runner.os }}.test-results
                   path: build/reports/tests
               if: ${{ always() }}
             - name: Upload Test Logs
-              uses: actions/upload-artifact@v2.2.4
+              uses: actions/upload-artifact@v4
               with:
                   name: ${{ runner.os }}.test-logs
                   path: build/idea-sandbox/system-test/log

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/godot/run/configurations/gdscript/GdScriptDebugAdapterSupportProvider.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/godot/run/configurations/gdscript/GdScriptDebugAdapterSupportProvider.kt
@@ -12,8 +12,8 @@ import com.intellij.platform.dap.DebugAdapterSupportProvider
 import com.intellij.platform.dap.connection.DebugAdapterHandle
 import com.intellij.platform.dap.connection.DebugAdapterSocketConnection
 import com.jetbrains.rider.plugins.godot.GodotPluginBundle
-import com.jetbrains.rider.plugins.godot.run.configurations.gdscript.brakepoints.GdScriptExceptionBreakpointType
-import com.jetbrains.rider.plugins.godot.run.configurations.gdscript.brakepoints.GdScriptLineBreakpointType
+import com.jetbrains.rider.plugins.godot.run.configurations.gdscript.breakpoints.GdScriptExceptionBreakpointType
+import com.jetbrains.rider.plugins.godot.run.configurations.gdscript.breakpoints.GdScriptLineBreakpointType
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/godot/run/configurations/gdscript/breakpoints/GdScriptExceptionBreakpointType.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/godot/run/configurations/gdscript/breakpoints/GdScriptExceptionBreakpointType.kt
@@ -1,4 +1,4 @@
-package com.jetbrains.rider.plugins.godot.run.configurations.gdscript.brakepoints
+package com.jetbrains.rider.plugins.godot.run.configurations.gdscript.breakpoints
 
 import com.intellij.xdebugger.breakpoints.XBreakpoint
 import com.intellij.xdebugger.breakpoints.XBreakpointProperties

--- a/rider/src/main/kotlin/com/jetbrains/rider/plugins/godot/run/configurations/gdscript/breakpoints/GdScriptLineBreakpointType.kt
+++ b/rider/src/main/kotlin/com/jetbrains/rider/plugins/godot/run/configurations/gdscript/breakpoints/GdScriptLineBreakpointType.kt
@@ -1,4 +1,4 @@
-package com.jetbrains.rider.plugins.godot.run.configurations.gdscript.brakepoints
+package com.jetbrains.rider.plugins.godot.run.configurations.gdscript.breakpoints
 
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile


### PR DESCRIPTION
Renamed files and package names from 'brakepoints' to 'breakpoints' to correct a spelling error. Updated all relevant import statements in GdScriptDebugAdapterSupportProvider.kt accordingly.