### PR TITLE
gdscript: Add separate highlighting for doc comments

### DIFF
--- a/gdscript/src/main/kotlin/gdscript/annotator/GdCommentAnnotator.kt
+++ b/gdscript/src/main/kotlin/gdscript/annotator/GdCommentAnnotator.kt
@@ -15,6 +15,12 @@ class GdCommentAnnotator : Annotator {
     override fun annotate(element: PsiElement, holder: AnnotationHolder) {
         if (element !is PsiComment) return
 
+        if (element.text.startsWith("##")) {
+            holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+                .textAttributes(GdHighlighterColors.DOC_COMMENT)
+                .create()
+        }
+
         val state = GdProjectSettingsState.getInstance(element).state
         val criticals = state.criticals.split(",")
         val warnings = state.warnings.split(",")
@@ -35,5 +41,4 @@ class GdCommentAnnotator : Annotator {
             }
         }
     }
-
 }

--- a/gdscript/src/main/kotlin/gdscript/highlighter/GdColorSettingsPage.kt
+++ b/gdscript/src/main/kotlin/gdscript/highlighter/GdColorSettingsPage.kt
@@ -6,7 +6,6 @@ import com.intellij.openapi.options.colors.AttributesDescriptor
 import com.intellij.openapi.options.colors.ColorDescriptor
 import com.intellij.openapi.options.colors.ColorSettingsPage
 import com.intellij.rider.plugins.godot.community.icons.RiderPluginsGodotCommunityIcons
-import gdscript.GdIcon
 import javax.swing.Icon
 
 class GdColorSettingsPage : ColorSettingsPage {
@@ -40,6 +39,7 @@ var v2 = Vector2(1, 2)
 # DANGER: danger comment
 # WARN: warning comment
 # NOTE: note comment
+## Documentation comment
 func _init():
     print("Constructed!")
     var local_var = 5
@@ -91,6 +91,7 @@ class Something:
             AttributesDescriptor("Static method call", GdHighlighterColors.STATIC_METHOD_CALL),
             AttributesDescriptor("Flow control", GdHighlighterColors.FLOW_KEYWORDS),
             AttributesDescriptor("Comments", GdHighlighterColors.COMMENT),
+            AttributesDescriptor("Doc comments", GdHighlighterColors.DOC_COMMENT),
             AttributesDescriptor("Critical comments", GdHighlighterColors.DANGER),
             AttributesDescriptor("Warning comments", GdHighlighterColors.WARNING),
             AttributesDescriptor("Note comments", GdHighlighterColors.NOTE),

--- a/gdscript/src/main/kotlin/gdscript/highlighter/GdHighlighterColors.kt
+++ b/gdscript/src/main/kotlin/gdscript/highlighter/GdHighlighterColors.kt
@@ -61,6 +61,11 @@ interface GdHighlighterColors {
             "GD_COMMENT", DefaultLanguageHighlighterColors.LINE_COMMENT
         )
 
+        // Soft translucent blue
+        val DOC_COMMENT = TextAttributesKey.createTextAttributesKey(
+            "GD_DOC_COMMENT", DefaultLanguageHighlighterColors.DOC_COMMENT
+        )
+
         // Yellow
         val STRING = TextAttributesKey.createTextAttributesKey(
             "GD_STRING", DefaultLanguageHighlighterColors.STRING

--- a/gdscript/src/main/resources/colorSchemes/GdDarculaColorScheme.xml
+++ b/gdscript/src/main/resources/colorSchemes/GdDarculaColorScheme.xml
@@ -80,6 +80,11 @@
             <option name="FOREGROUND" value="cdcfd280" />
         </value>
     </option>
+    <option name="GD_DOC_COMMENT">
+        <value>
+            <option name="FOREGROUND" value="99b3cccc" />
+        </value>
+    </option>
     <option name="GD_STRING_FORMAT">
         <value>
             <option name="FOREGROUND" value="badeff" />


### PR DESCRIPTION
Was missing different doc comments coloring in GDScript from the built-in Godot editor:

Godot built-in editor:
<img width="559" height="168" alt="godot" src="https://github.com/user-attachments/assets/17295795-1576-4bef-98d3-3c7d7eb51702" />

Intellij with Darcula before patch:
<img width="489" height="186" alt="image" src="https://github.com/user-attachments/assets/d9e7891c-b170-4cce-9707-ccad9f754038" />

Intellij with Darcula after patch:
<img width="506" height="168" alt="darcula" src="https://github.com/user-attachments/assets/71604a3a-5a15-406d-ba60-2ef197710e75" />

Unfortunately does not show in the GDScript's Color Scheme preview  (same as the critical/warning/note comments), since it is implemented as an annotator.

The config after patch:
<img width="655" height="580" alt="rider_config" src="https://github.com/user-attachments/assets/6dabefa2-c30e-4ed2-937e-2b61fba8076c" />