### PR TITLE
Return Callable for lambda funcs, add invokedReturnType

### DIFF
--- a/gdscript/src/main/gen/gdscript/psi/GdFuncDeclEx.java
+++ b/gdscript/src/main/gen/gdscript/psi/GdFuncDeclEx.java
@@ -23,7 +23,7 @@ public interface GdFuncDeclEx extends GdExpr, GdDocumented {
   GdStmtOrSuite getStmtOrSuite();
 
   @NotNull
-  String getReturnType();
+  String getInvokedReturnType();
 
   @Nullable
   PsiElement getReturnExpr();

--- a/gdscript/src/main/gen/gdscript/psi/impl/GdFuncDeclExImpl.java
+++ b/gdscript/src/main/gen/gdscript/psi/impl/GdFuncDeclExImpl.java
@@ -3,6 +3,7 @@ package gdscript.psi.impl;
 
 import java.util.List;
 
+import gdscript.GdKeywords;
 import gdscript.model.GdTutorial;
 import gdscript.psi.utils.GdCommentUtil;
 import org.jetbrains.annotations.*;
@@ -58,7 +59,13 @@ public class GdFuncDeclExImpl extends GdExprImpl implements GdFuncDeclEx {
   @Override
   @NotNull
   public String getReturnType() {
-    return GdPsiUtils.getReturnType(this);
+    return GdKeywords.CALLABLE;
+  }
+
+  @Override
+  @NotNull
+  public String getInvokedReturnType() {
+    return GdPsiUtils.getInvokedReturnType(this);
   }
 
   @Override

--- a/gdscript/src/main/kotlin/gdscript/psi/GdPsiUtils.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/GdPsiUtils.kt
@@ -90,7 +90,7 @@ object GdPsiUtils {
     @JvmStatic fun getReturnType(element: GdArgExpr): String = PsiGdExprUtil.getReturnType(element.expr)
 
     /** Lambdas */
-    @JvmStatic fun getReturnType(element: GdFuncDeclEx): String = PsiGdLocalFuncUtil.getReturnType(element)
+    @JvmStatic fun getInvokedReturnType(element: GdFuncDeclEx): String = PsiGdLocalFuncUtil.getReturnType(element)
     // TODO remove?
     @JvmStatic fun getReturnExpr(element: GdFuncDeclEx): PsiElement? = PsiGdLocalFuncUtil.getReturnExpr(element)
     @JvmStatic fun getParameters(element: GdFuncDeclEx): LinkedHashMap<String, String?> = PsiGdLocalFuncUtil.getParameters(element)

--- a/gdscript/src/test/kotlin/com/jetbrains/godot/gdscript/parser/GdCallableInferenceTest.kt
+++ b/gdscript/src/test/kotlin/com/jetbrains/godot/gdscript/parser/GdCallableInferenceTest.kt
@@ -1,0 +1,23 @@
+package com.jetbrains.godot.gdscript.parser
+
+import com.intellij.psi.util.descendantsOfType
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import gdscript.psi.GdFuncDeclEx
+import gdscript.psi.GdVarDeclSt
+
+class GdCallableInferenceTest : BasePlatformTestCase() {
+
+    fun testLambdaInference() {
+        //language=GDScript
+        val code = """
+            func hello():
+                var thing := func() -> String:
+                    return ""
+        """.trimIndent()
+        val file = myFixture.configureByText("test.gd", code)
+        val varDecl = file.descendantsOfType<GdVarDeclSt>().first { it.name == "thing" }
+        val funcDecl = varDecl.descendantsOfType<GdFuncDeclEx>().single()
+        assertEquals("Callable", varDecl.returnType)
+        assertEquals("String", funcDecl.invokedReturnType)
+    }
+}


### PR DESCRIPTION
Fixes RIDER-130139

Currently, `returnType` is inconsistent between Callable vars and all other vars: for all other vars `returnType` is the type of the var, but for Callable vars `returnType` is the type that the callable itself returns. This leads to the bug in the ticket.

This fixes it, though not totally eliminating the confusion, by:
- Changing `returnType` to Callable for local function var declarations
- Adding `invokedReturnType` to local function var declarations to get their return type

As I committed this I realized the Gd psi classes are generated, so I need to update wherever they come from and regenerate them. Any pointers on how to do that?
