### PR TITLE
RIDER-130403 - Rename `script_class` references in .tres/.tscn files with GDScript class rename

### DIFF
--- a/gdscript/src/main/kotlin/tscn/completion/TscnScriptClassReferenceContributor.kt
+++ b/gdscript/src/main/kotlin/tscn/completion/TscnScriptClassReferenceContributor.kt
@@ -1,0 +1,30 @@
+package tscn.completion
+
+import com.intellij.patterns.PlatformPatterns.psiElement
+import com.intellij.psi.*
+import com.intellij.util.ProcessingContext
+import tscn.psi.TscnHeaderValueVal
+import tscn.psi.TscnTypes
+import tscn.reference.TscnScriptClassReference
+
+const val SCRIPT_CLASS_KEY = "script_class"
+
+class TscnScriptClassReferenceContributor : PsiReferenceContributor() {
+
+    private val PATTERN = psiElement(TscnTypes.HEADER_VALUE_VAL)
+        .withParent(
+            psiElement(TscnTypes.HEADER_VALUE)
+                .withChild(
+                    psiElement(TscnTypes.HEADER_VALUE_NM)
+                        .withText(SCRIPT_CLASS_KEY)
+                )
+        )
+
+    override fun registerReferenceProviders(registrar: PsiReferenceRegistrar) =
+        registrar.registerReferenceProvider(PATTERN, TscnReferenceProvider)
+
+    object TscnReferenceProvider : PsiReferenceProvider() {
+        override fun getReferencesByElement(element: PsiElement, context: ProcessingContext): Array<PsiReference> =
+            arrayOf(TscnScriptClassReference(element as TscnHeaderValueVal))
+    }
+}

--- a/gdscript/src/main/kotlin/tscn/psi/TscnElementFactory.kt
+++ b/gdscript/src/main/kotlin/tscn/psi/TscnElementFactory.kt
@@ -12,7 +12,7 @@ import tscn.TscnFileType
 object TscnElementFactory {
 
     fun tscnNodeHeaderValueVal(project: Project, name: String): PsiElement {
-        val file = createFile(project, "[ext_resource path=\"res://$name\"]\n")
+        val file = createFile(project, "[ext_resource path=\"$name\"]\n")
 
         return PsiTreeUtil.findChildOfType(file, TscnHeaderValueVal::class.java)!!.firstChild
     }

--- a/gdscript/src/main/kotlin/tscn/reference/TscnScriptClassReference.kt
+++ b/gdscript/src/main/kotlin/tscn/reference/TscnScriptClassReference.kt
@@ -1,0 +1,33 @@
+package tscn.reference
+
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiNamedElement
+import com.intellij.psi.PsiReferenceBase
+import com.intellij.psi.impl.source.resolve.ResolveCache
+import gdscript.psi.utils.GdClassUtil
+import tscn.psi.TscnElementFactory
+
+class TscnScriptClassReference : PsiReferenceBase<PsiNamedElement> {
+
+    constructor(element: PsiNamedElement) : super(element, TextRange(0, element.textLength))
+
+    override fun resolve(): PsiElement? {
+        val cache = ResolveCache.getInstance(element.project)
+        return cache.resolveWithCaching(
+            this,
+            ResolveCache.Resolver { _, _ ->
+                val className = element.text.trim('"')
+                val classIdElement = GdClassUtil.getClassIdElement(className, element, element.project)
+                classIdElement
+            },
+            false,
+            false,
+        )
+    }
+
+    override fun handleElementRename(newElementName: String): PsiElement {
+        element.setName(newElementName)
+        return element
+    }
+}

--- a/gdscript/src/main/resources/META-INF/plugin.xml
+++ b/gdscript/src/main/resources/META-INF/plugin.xml
@@ -96,6 +96,7 @@
     <psi.referenceContributor language="GdScript" implementation="gdscript.completion.GdResourceReferenceContributor" />
     <!-- Tscn, Project, Config -->
     <psi.referenceContributor language="Tscn" implementation="tscn.completion.TscnResourceReferenceContributor" />
+    <psi.referenceContributor language="Tscn" implementation="tscn.completion.TscnScriptClassReferenceContributor"/>
 
     <!-- Annotators -->
     <annotator language="GdScript" implementationClass="gdscript.annotator.GdClassNameAnnotator" />

--- a/gdscript/src/test/kotlin/com/jetbrains/godot/tscn/refactoring/rename/ScriptClassRenamingTest.kt
+++ b/gdscript/src/test/kotlin/com/jetbrains/godot/tscn/refactoring/rename/ScriptClassRenamingTest.kt
@@ -1,0 +1,18 @@
+package com.jetbrains.godot.tscn.refactoring.rename
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.jetbrains.godot.getBaseTestDataPath
+import kotlin.io.path.pathString
+
+class ScriptClassRenamingTest : BasePlatformTestCase() {
+    override fun getTestDataPath(): String {
+        return getBaseTestDataPath().resolve("testData/tscn/refactoring/rename/scriptClassRenaming").pathString
+    }
+
+    fun testRename() {
+        myFixture.configureByFiles("simple_resource.gd", "simple_resource.tres")
+        myFixture.renameElementAtCaret("SimpleResourceRenamed")
+        myFixture.checkResultByFile("simple_resource.gd", "simple_resource.gd.after", false)
+        myFixture.checkResultByFile("simple_resource.tres", "simple_resource.tres.after", false)
+    }
+}

--- a/gdscript/src/test/testData/tscn/refactoring/rename/scriptClassRenaming/simple_resource.gd
+++ b/gdscript/src/test/testData/tscn/refactoring/rename/scriptClassRenaming/simple_resource.gd
@@ -1,0 +1,3 @@
+class_name SimpleResource<caret> extends Resource
+
+@export var value: String = ""

--- a/gdscript/src/test/testData/tscn/refactoring/rename/scriptClassRenaming/simple_resource.gd.after
+++ b/gdscript/src/test/testData/tscn/refactoring/rename/scriptClassRenaming/simple_resource.gd.after
@@ -1,0 +1,3 @@
+class_name SimpleResourceRenamed extends Resource
+
+@export var value: String = ""

--- a/gdscript/src/test/testData/tscn/refactoring/rename/scriptClassRenaming/simple_resource.tres
+++ b/gdscript/src/test/testData/tscn/refactoring/rename/scriptClassRenaming/simple_resource.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" script_class="SimpleResource" load_steps=2 format=3 uid="uid://cj83h232urbtm"]
+
+[ext_resource type="Script" uid="uid://cajacij1ntk65" path="res://simple_resource.gd" id="1_hn4mw"]
+
+[resource]
+script = ExtResource("1_hn4mw")
+value = "foobar"
+metadata/_custom_type_script = "uid://cajacij1ntk65"

--- a/gdscript/src/test/testData/tscn/refactoring/rename/scriptClassRenaming/simple_resource.tres.after
+++ b/gdscript/src/test/testData/tscn/refactoring/rename/scriptClassRenaming/simple_resource.tres.after
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" script_class="SimpleResourceRenamed" load_steps=2 format=3 uid="uid://cj83h232urbtm"]
+
+[ext_resource type="Script" uid="uid://cajacij1ntk65" path="res://simple_resource.gd" id="1_hn4mw"]
+
+[resource]
+script = ExtResource("1_hn4mw")
+value = "foobar"
+metadata/_custom_type_script = "uid://cajacij1ntk65"


### PR DESCRIPTION
This change includes a reference contributor for .tscn/.tres `script_class` header values, which resolve to the appropriate GDScript class declaration.

There was a slight change to the `TscnElementFactory` class to not forcibly prepend `res://` to any created header values.

Includes a test for the case described in RIDER-130403

Checklist for new contributions
- [x] The fix or feature implementation is included in this PR
- [x] Tests are added/updated as per documentation/contribution/tests.md
  - [x] I ran: ./gradlew test and verified they pass locally
- [x] Optional: A YouTrack issue is linked to keep QA and release notes in the loop (https://youtrack.jetbrains.com/issues)
