### PR TITLE
Fix RIDER-130512

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,15 @@ gdscript/build
 gdscript/protocol/build
 gdscript/classes
 
+community/.intellijPlatform
+community/build
+community/protocol/build
+community/classes
+community/nuget
+
 *generated*
 *Generated*
 
 NuGet.Config
+
+*.hprof

--- a/gdscript/src/main/kotlin/tscn/completion/TscnResourceFieldReferenceContributor.kt
+++ b/gdscript/src/main/kotlin/tscn/completion/TscnResourceFieldReferenceContributor.kt
@@ -1,0 +1,24 @@
+package tscn.completion
+
+import com.intellij.patterns.PlatformPatterns.psiElement
+import com.intellij.psi.*
+import com.intellij.util.ProcessingContext
+import tscn.psi.TscnDataLineNm
+import tscn.psi.TscnTypes
+import tscn.reference.TscnResourceFieldReference
+
+/**
+ * Represents a reference to a field of a Resource class in a .tscn/.tres file.
+ */
+class TscnResourceFieldReferenceContributor : PsiReferenceContributor() {
+
+    private val PATTERN = psiElement(TscnTypes.DATA_LINE_NM)
+
+    override fun registerReferenceProviders(registrar: PsiReferenceRegistrar) =
+        registrar.registerReferenceProvider(PATTERN, TscnResourceFieldReferenceProvider)
+
+    object TscnResourceFieldReferenceProvider : PsiReferenceProvider() {
+        override fun getReferencesByElement(element: PsiElement, context: ProcessingContext): Array<PsiReference> =
+            arrayOf(TscnResourceFieldReference(element as TscnDataLineNm))
+    }
+}

--- a/gdscript/src/main/kotlin/tscn/psi/TscnElementFactory.kt
+++ b/gdscript/src/main/kotlin/tscn/psi/TscnElementFactory.kt
@@ -17,6 +17,20 @@ object TscnElementFactory {
         return PsiTreeUtil.findChildOfType(file, TscnHeaderValueVal::class.java)!!.firstChild
     }
 
+    /**
+     * Create and return a [TscnDataLineNm] element with the given [name].
+     *
+     * @param project   The project in which to create the element
+     * @param name      The name of the new element
+     *
+     * @return A [TscnDataLineNm] element with the given name.
+     */
+    fun tscnDataLineNm(project: Project, name: String): PsiElement {
+        val file = createFile(project, "[resource]\n$name = \"\"")
+
+        return PsiTreeUtil.findChildOfType(file, TscnDataLineNm::class.java)!!.firstChild
+    }
+
     private fun createFile(project: Project, text: String) =
         PsiFileFactory.getInstance(project).createFileFromText("dum.tscn", TscnFileType, text) as TscnFile
 

--- a/gdscript/src/main/kotlin/tscn/psi/utils/TscnCommonUtil.kt
+++ b/gdscript/src/main/kotlin/tscn/psi/utils/TscnCommonUtil.kt
@@ -1,6 +1,7 @@
 package tscn.psi.utils
 
 import com.intellij.psi.PsiElement
+import tscn.psi.TscnDataLineNm
 import tscn.psi.TscnElementFactory
 import tscn.psi.TscnHeaderValueVal
 import tscn.psi.TscnNamedElement
@@ -19,6 +20,7 @@ object TscnCommonUtil {
         if (keyNode != null) {
             val id = when(element) {
                 is TscnHeaderValueVal -> TscnElementFactory.tscnNodeHeaderValueVal(element.project, newName)
+                is TscnDataLineNm -> TscnElementFactory.tscnDataLineNm(element.project, newName)
                 else -> return element
             }
             element.node.replaceChild(keyNode, id.node)

--- a/gdscript/src/main/kotlin/tscn/psi/utils/TscnParagraphUtil.kt
+++ b/gdscript/src/main/kotlin/tscn/psi/utils/TscnParagraphUtil.kt
@@ -1,0 +1,19 @@
+package tscn.psi.utils
+
+import tscn.psi.TscnDataLine
+import tscn.psi.TscnParagraph
+
+object TscnParagraphUtil {
+    /**
+     * Get the [TscnDataLine] in the specified [TscnParagraph] that assigns the specified [fieldName], or `null` if no
+     * such line exists.
+     *
+     * @param paragraph The [TscnParagraph] in which to search for the specified field.
+     * @param fieldName The name of the field being set by the [TscnDataLine].
+     *
+     * @return A [TscnDataLine] that sets the specified field, or `null` if no such line exists.
+     */
+    fun getDataLine(paragraph: TscnParagraph, fieldName: String): TscnDataLine? {
+        return paragraph.dataLineList.firstOrNull { it.dataLineHeader.text == fieldName }
+    }
+}

--- a/gdscript/src/main/kotlin/tscn/reference/TscnResourceFieldReference.kt
+++ b/gdscript/src/main/kotlin/tscn/reference/TscnResourceFieldReference.kt
@@ -1,0 +1,101 @@
+package tscn.reference
+
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiManager
+import com.intellij.psi.PsiNamedElement
+import com.intellij.psi.PsiReferenceBase
+import com.intellij.psi.impl.source.resolve.ResolveCache
+import com.intellij.psi.search.FileTypeIndex
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.util.childrenOfType
+import com.intellij.psi.util.parentOfType
+import com.jetbrains.rider.godot.community.gdscript.GdFileType
+import gdscript.psi.GdClassNameNmi
+import gdscript.psi.GdClassNaming
+import gdscript.psi.GdClassVarDeclTl
+import gdscript.psi.GdVarNmi
+import gdscript.psi.utils.GdClassMemberUtil
+import gdscript.utils.VirtualFileUtil.localPath
+import tscn.psi.TscnDataLineNm
+import tscn.psi.TscnParagraph
+import tscn.psi.TscnResourceHeader
+import tscn.psi.utils.TscnHeaderUtils
+import tscn.psi.utils.TscnParagraphUtil
+
+class TscnResourceFieldReference : PsiReferenceBase<PsiNamedElement> {
+
+    constructor(element: PsiNamedElement) : super(element, TextRange(0, element.textLength))
+
+    override fun resolve(): PsiElement? {
+        val cache = ResolveCache.getInstance(element.project)
+        return cache.resolveWithCaching(
+            this,
+            ResolveCache.Resolver { _, _ -> resolveScriptVariable(this.element) },
+            false,
+            false,
+        )
+    }
+
+    override fun handleElementRename(newElementName: String): PsiElement {
+        element.setName(newElementName)
+        return element
+    }
+
+    private fun resolveScriptVariable(fieldElement: PsiNamedElement): PsiNamedElement? {
+        if (fieldElement !is TscnDataLineNm) return null
+        val fieldName = fieldElement.name
+        val resourceId = getScriptResourceIdOfContainingParagraph(fieldElement) ?: return null
+        val path = getScriptPathFromResourceId(fieldElement, resourceId) ?: return null
+        val classDeclaration = getTopLevelClassDeclarationFromPath(fieldElement, path) ?: return null
+        val classVarDeclaration = findClassVarDeclaration(classDeclaration, fieldName)
+        return classVarDeclaration
+    }
+
+    private fun getScriptResourceIdOfContainingParagraph(fieldElement: TscnDataLineNm): String? {
+        val paragraph = fieldElement.parentOfType<TscnParagraph>() ?: return null
+        val scriptDataLine = TscnParagraphUtil.getDataLine(paragraph, "script") ?: return null
+        val scriptExprVal = scriptDataLine.dataLineValue.value.exprValue ?: return null
+        if (scriptExprVal.identifierEx.text != "ExtResource") return null
+        val scriptExprValArg0 = scriptExprVal.argList?.valueList?.firstOrNull() ?: return null
+        return scriptExprValArg0.text.trim('"')
+    }
+
+    private fun getScriptPathFromResourceId(fieldElement: PsiNamedElement, resourceId: String): String? {
+        // Find resource header with matching id, get script_class header value
+        val resourceHeader = fieldElement.containingFile
+            .childrenOfType<TscnParagraph>()
+            .mapNotNull { it.header as? TscnResourceHeader }
+            .firstOrNull { TscnHeaderUtils.getValue(it.headerValueList, "id") == resourceId }
+            ?: return null
+
+        val path = TscnHeaderUtils.getValue(resourceHeader.headerValueList, "path")
+
+        return path.removePrefix("res://")
+    }
+
+    private fun getTopLevelClassDeclarationFromPath(fieldElement: PsiNamedElement, path: String): GdClassNameNmi? {
+        val searchScope = GlobalSearchScope.projectScope(fieldElement.project)
+        val candidateFiles = FileTypeIndex.getFiles(GdFileType, searchScope)
+        val sourceFile = candidateFiles.firstOrNull {
+            it.localPath().ifEmpty { it.path }.endsWith(path)
+        } ?: return null
+        val sourceGdPsi = PsiManager.getInstance(fieldElement.project).findFile(sourceFile) ?: return null
+        val classDeclaration = sourceGdPsi.childrenOfType<GdClassNaming>().firstOrNull()?.classNameNmi ?: return null
+        return classDeclaration
+    }
+
+    private fun findClassVarDeclaration(classDeclaration: GdClassNameNmi, fieldName: String): GdVarNmi? {
+        val declarationCandidates = GdClassMemberUtil.listDeclarations(classDeclaration, fieldName)
+
+        if (declarationCandidates.isEmpty()) return null
+
+        for (declaration in declarationCandidates) {
+            if (declaration is GdClassVarDeclTl && declaration.name == fieldName) {
+                return declaration.varNmi
+            }
+        }
+
+        return null
+    }
+}

--- a/gdscript/src/main/resources/META-INF/plugin.xml
+++ b/gdscript/src/main/resources/META-INF/plugin.xml
@@ -97,6 +97,7 @@
     <!-- Tscn, Project, Config -->
     <psi.referenceContributor language="Tscn" implementation="tscn.completion.TscnResourceReferenceContributor" />
     <psi.referenceContributor language="Tscn" implementation="tscn.completion.TscnScriptClassReferenceContributor"/>
+    <psi.referenceContributor language="Tscn" implementation="tscn.completion.TscnResourceFieldReferenceContributor"/>
 
     <!-- Annotators -->
     <annotator language="GdScript" implementationClass="gdscript.annotator.GdClassNameAnnotator" />

--- a/gdscript/src/test/kotlin/com/jetbrains/godot/tscn/refactoring/rename/ResourceFieldRenamingTest.kt
+++ b/gdscript/src/test/kotlin/com/jetbrains/godot/tscn/refactoring/rename/ResourceFieldRenamingTest.kt
@@ -1,0 +1,19 @@
+package com.jetbrains.godot.tscn.refactoring.rename
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.jetbrains.godot.getBaseTestDataPath
+import kotlin.io.path.pathString
+
+class ResourceFieldRenamingTest : BasePlatformTestCase() {
+
+    override fun getTestDataPath(): String {
+        return getBaseTestDataPath().resolve("testData/tscn/refactoring/rename/resourceFieldRenaming").pathString
+    }
+
+    fun testRename() {
+        myFixture.configureByFiles("simple_resource.gd", "simple_resource.tres")
+        myFixture.renameElementAtCaret("valueRenamed")
+        myFixture.checkResultByFile("simple_resource.gd", "simple_resource.gd.after", false)
+        myFixture.checkResultByFile("simple_resource.tres", "simple_resource.tres.after", false)
+    }
+}

--- a/gdscript/src/test/testData/tscn/refactoring/rename/resourceFieldRenaming/simple_resource.gd
+++ b/gdscript/src/test/testData/tscn/refactoring/rename/resourceFieldRenaming/simple_resource.gd
@@ -1,0 +1,3 @@
+class_name SimpleResource extends Resource
+
+@export var value<caret>: String = ""

--- a/gdscript/src/test/testData/tscn/refactoring/rename/resourceFieldRenaming/simple_resource.gd.after
+++ b/gdscript/src/test/testData/tscn/refactoring/rename/resourceFieldRenaming/simple_resource.gd.after
@@ -1,0 +1,3 @@
+class_name SimpleResource extends Resource
+
+@export var valueRenamed: String = ""

--- a/gdscript/src/test/testData/tscn/refactoring/rename/resourceFieldRenaming/simple_resource.tres
+++ b/gdscript/src/test/testData/tscn/refactoring/rename/resourceFieldRenaming/simple_resource.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" script_class="SimpleResource" load_steps=2 format=3 uid="uid://cj83h232urbtm"]
+
+[ext_resource type="Script" uid="uid://cajacij1ntk65" path="res://simple_resource.gd" id="1_hn4mw"]
+
+[resource]
+script = ExtResource("1_hn4mw")
+value = "foobar"
+metadata/_custom_type_script = "uid://cajacij1ntk65"

--- a/gdscript/src/test/testData/tscn/refactoring/rename/resourceFieldRenaming/simple_resource.tres.after
+++ b/gdscript/src/test/testData/tscn/refactoring/rename/resourceFieldRenaming/simple_resource.tres.after
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" script_class="SimpleResource" load_steps=2 format=3 uid="uid://cj83h232urbtm"]
+
+[ext_resource type="Script" uid="uid://cajacij1ntk65" path="res://simple_resource.gd" id="1_hn4mw"]
+
+[resource]
+script = ExtResource("1_hn4mw")
+valueRenamed = "foobar"
+metadata/_custom_type_script = "uid://cajacij1ntk65"


### PR DESCRIPTION
Title: [RIDER-130512](https://youtrack.jetbrains.com/issue/RIDER-130512) Renaming a field in a GDScript Resource class should rename the field in .tscn/.tres files as well


Summary:
- Add .hprof and community build files to .gitignore
- Add function to create `TscnDataLineNm` elements
- Support renaming TscnDataLineNm elements
- Add test for renaming Resource fields in .tres files
- Add utility function for getting specific data line
- Add `TscnResourceFieldReference` Attempts to resolve to a script class var based on the id of the `script` field in the containing .tscn "paragraph"
- Add `TscnResourceFieldReferenceContributor`

Currently attaches references to all `TscnDataLineNm` nodes, if this is too broad it could be tightened up.


Checklist for new contributions
- [x] The fix or feature implementation is included in this PR
- [x] Tests are added/updated as per documentation/contribution/tests.md
  - [x] I ran: ./gradlew test and verified they pass locally
- [x] Optional: A YouTrack issue is linked to keep QA and release notes in the loop (https://youtrack.jetbrains.com/issues)
  -  [RIDER-130512](https://youtrack.jetbrains.com/issue/RIDER-130512)
