### PR TITLE
remove redundant semicolons

### DIFF
--- a/gdscript/src/main/kotlin/common/index/StringStubIndexExtensionExt.kt
+++ b/gdscript/src/main/kotlin/common/index/StringStubIndexExtensionExt.kt
@@ -98,15 +98,15 @@ abstract class StringStubIndexExtensionExt<Psi : PsiElement?> : StringStubIndexE
     }
 
     fun getNonEmptyKeys(project: Project): Collection<String> {
-        if (DumbService.isDumb(project)) return emptyList();
+        if (DumbService.isDumb(project)) return emptyList()
         return getAllKeys(project).mapNotNull {
             if (it.isNotBlank() && getGlobally(it, project).isNotEmpty()) it else null
         }
     }
 
     fun getAllValues(project: Project): Collection<Psi> {
-        if (DumbService.isDumb(project)) return emptyList();
-        return getAllKeys(project).flatMap { getGlobally(it, project) };
+        if (DumbService.isDumb(project)) return emptyList()
+        return getAllKeys(project).flatMap { getGlobally(it, project) }
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/GdKeywords.kt
+++ b/gdscript/src/main/kotlin/gdscript/GdKeywords.kt
@@ -29,7 +29,7 @@ object GdKeywords {
     const val INF = "INF"
     const val TAU = "TAU"
     const val PI = "PI"
-    val MATH_CONSTANTS = setOf(PI, TAU, INF, NAN);
+    val MATH_CONSTANTS = setOf(PI, TAU, INF, NAN)
 
     /** Return types */
     const val INT = "int"
@@ -40,7 +40,7 @@ object GdKeywords {
     const val DICTIONARY = "Dictionary"
     const val STR_NAME = "StringName"
     const val NODE_PATH = "NodePath"
-    val BUILT_TYPES = setOf(INT, STR, FLOAT, BOOL, ARRAY, DICTIONARY);
+    val BUILT_TYPES = setOf(INT, STR, FLOAT, BOOL, ARRAY, DICTIONARY)
     const val VOID = "void"
     const val CALLABLE = "Callable"
 
@@ -50,24 +50,24 @@ object GdKeywords {
     const val GLOBAL_SCOPE = "_GlobalScope"
     const val GLOBAL_GD_SCRIPT = "_GDScript"
 
-    const val INIT_METHOD = "_init";
+    const val INIT_METHOD = "_init"
 
     /** Flow Types */
-    const val FLOW_RETURN = "return";
+    const val FLOW_RETURN = "return"
 
-    val LITERALS = arrayOf(TRUE, FALSE, NULL);
-    val LITERAL_TYPES = arrayOf(BOOL, BOOL, NULL);
+    val LITERALS = arrayOf(TRUE, FALSE, NULL)
+    val LITERAL_TYPES = arrayOf(BOOL, BOOL, NULL)
 
     /** Annotations */
-    val ANNOTATION_TOOL = "tool";
-    val ANNOTATION_EXPORT = "export";
-    val ANNOTATION_ONREADY = "onready";
-    val ANNOTATION_ICON = "icon";
+    val ANNOTATION_TOOL = "tool"
+    val ANNOTATION_EXPORT = "export"
+    val ANNOTATION_ONREADY = "onready"
+    val ANNOTATION_ICON = "icon"
 
     // TODO delete - use?
     val ANNOTATIONS_ROOT_ONLY = arrayOf(
         ANNOTATION_TOOL,
         ANNOTATION_ICON,
-    );
+    )
 
 }

--- a/gdscript/src/main/kotlin/gdscript/GdLexerHighlighterAdapter.kt
+++ b/gdscript/src/main/kotlin/gdscript/GdLexerHighlighterAdapter.kt
@@ -4,6 +4,6 @@ import com.intellij.lexer.FlexAdapter
 
 class GdLexerHighlighterAdapter : FlexAdapter {
 
-    constructor() : super(GdLexerHighlighter(null));
+    constructor() : super(GdLexerHighlighter(null))
 
 }

--- a/gdscript/src/main/kotlin/gdscript/GdParserDefinition.kt
+++ b/gdscript/src/main/kotlin/gdscript/GdParserDefinition.kt
@@ -23,7 +23,7 @@ class GdParserDefinition : ParserDefinition {
     companion object {
         val COMMENTS = TokenSet.create(GdTypes.COMMENT, GdTypes.BACKSLASH)
         val STRING_LITERALS = TokenSet.create(GdTypes.STRING)
-        val FILE = IStubFileElementType<PsiFileStub<GdFile>>("GdScriptFile", GdLanguage);
+        val FILE = IStubFileElementType<PsiFileStub<GdFile>>("GdScriptFile", GdLanguage)
     }
 
     override fun createLexer(project: Project): Lexer {

--- a/gdscript/src/main/kotlin/gdscript/GdTemplateContextType.kt
+++ b/gdscript/src/main/kotlin/gdscript/GdTemplateContextType.kt
@@ -6,6 +6,6 @@ import com.intellij.codeInsight.template.TemplateContextType
 class GdTemplateContextType : TemplateContextType("GdScript") {
 
     override fun isInContext(templateActionContext: TemplateActionContext): Boolean =
-        templateActionContext.file.name.endsWith(".gd");
+        templateActionContext.file.name.endsWith(".gd")
 
 }

--- a/gdscript/src/main/kotlin/gdscript/action/GdCreateMethodAction.kt
+++ b/gdscript/src/main/kotlin/gdscript/action/GdCreateMethodAction.kt
@@ -12,10 +12,10 @@ import gdscript.utils.EditorSettingsUtil.normalIndent
 
 class GdCreateMethodAction : BaseIntentionAction {
 
-    val name: String;
-    val returnType: String?;
-    val parameters: Array<String>;
-    val bodyLines: Array<String>;
+    val name: String
+    val returnType: String?
+    val parameters: Array<String>
+    val bodyLines: Array<String>
 
     constructor(
         name: String,
@@ -23,10 +23,10 @@ class GdCreateMethodAction : BaseIntentionAction {
         parameters: Array<String> = emptyArray(),
         bodyLines: Array<String> = arrayOf("pass"),
     ) {
-        this.name = name;
-        this.returnType = returnType;
-        this.parameters = parameters;
-        this.bodyLines = bodyLines;
+        this.name = name
+        this.returnType = returnType
+        this.parameters = parameters
+        this.bodyLines = bodyLines
     }
 
     override fun getText(): String = "Create method"
@@ -34,19 +34,19 @@ class GdCreateMethodAction : BaseIntentionAction {
     override fun getFamilyName(): String = "Create method"
 
     override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?): Boolean {
-        return true;
+        return true
     }
 
     override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
         if (file === null || editor === null) {
-            return;
+            return
         }
 
-        val after = PsiTreeUtil.getDeepestVisibleLast(file) ?: return;
-        editor.caretModel.moveToOffset(after.endOffset);
+        val after = PsiTreeUtil.getDeepestVisibleLast(file) ?: return
+        editor.caretModel.moveToOffset(after.endOffset)
 
-        val method = StringBuilder("\n\n\n");
-        method.append("func $name(${parameters.joinToString()})");
+        val method = StringBuilder("\n\n\n")
+        method.append("func $name(${parameters.joinToString()})")
         if (returnType != null && returnType.isNotBlank()) {
             method.append(" -> $returnType")
         }
@@ -54,11 +54,11 @@ class GdCreateMethodAction : BaseIntentionAction {
         val indent = editor.settings.normalIndent(project)
 
         bodyLines.forEach {
-            method.append("$indent$it");
+            method.append("$indent$it")
         }
 
-        EditorModificationUtil.insertStringAtCaret(editor, method.toString());
-        PsiDocumentManager.getInstance(project).commitDocument(editor.document);
+        EditorModificationUtil.insertStringAtCaret(editor, method.toString())
+        PsiDocumentManager.getInstance(project).commitDocument(editor.document)
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/action/GdRemoveSetGetAction.kt
+++ b/gdscript/src/main/kotlin/gdscript/action/GdRemoveSetGetAction.kt
@@ -16,33 +16,33 @@ import gdscript.psi.GdSetgetDecl
 class GdRemoveSetGetAction : BaseIntentionAction() {
 
     override fun getText(): String {
-        return "Remove get & set";
+        return "Remove get & set"
     }
 
     override fun getFamilyName(): String {
-        return "Remove get & set";
+        return "Remove get & set"
     }
 
     override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?): Boolean {
-        if (editor === null || file === null) return false;
+        if (editor === null || file === null) return false
 
-        return getDeclaration(editor, file) != null;
+        return getDeclaration(editor, file) != null
     }
 
     override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
-        if (editor === null || file === null) return;
-        val element = getDeclaration(editor, file) ?: return;
+        if (editor === null || file === null) return
+        val element = getDeclaration(editor, file) ?: return
 
         arrayOf(GdSetMethodIdRef::class.java, GdGetMethodIdRef::class.java).forEach {
             val name = PsiTreeUtil.findChildOfType(element, it)
-            if (name != null) GdMethodDeclIndex.INSTANCE.getInFile(name).firstOrNull()?.delete();
+            if (name != null) GdMethodDeclIndex.INSTANCE.getInFile(name).firstOrNull()?.delete()
         }
 
-        element.delete();
+        element.delete()
     }
 
     private fun getDeclaration(editor: Editor, file: PsiFile): GdSetgetDecl? {
-        return PsiTreeUtil.getParentOfType(file.findElementAt(editor.caretModel.offset), GdSetgetDecl::class.java);
+        return PsiTreeUtil.getParentOfType(file.findElementAt(editor.caretModel.offset), GdSetgetDecl::class.java)
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/action/GdRunAction.kt
+++ b/gdscript/src/main/kotlin/gdscript/action/GdRunAction.kt
@@ -97,7 +97,7 @@ class GdRunAction : RunAnythingAction {
         NotificationGroupManager.getInstance()
                 .getNotificationGroup(PluginConstants.RUN_NOTIFICATION_GROUP_ID)
                 .createNotification(GdScriptBundle.message("notification.content.failed.to.run.due.to", message), NotificationType.WARNING)
-                .notify(project);
+                .notify(project)
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/action/util/IndentUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/action/util/IndentUtil.kt
@@ -13,27 +13,27 @@ object IndentUtil {
      *  - count: true -> number of indents (spaces / tabSize)
      */
     fun Editor.indents(element: PsiElement, count: Boolean = false): Int {
-        val line = document.getLineNumber(element.startOffset);
-        val indentStart = document.getLineStartOffset(line);
-        val indentEnd = EditorActionUtil.findFirstNonSpaceOffsetOnTheLine(document, line);
+        val line = document.getLineNumber(element.startOffset)
+        val indentStart = document.getLineStartOffset(line)
+        val indentEnd = EditorActionUtil.findFirstNonSpaceOffsetOnTheLine(document, line)
 
-        val editorSettings = settings;
-        val indentSize = indentEnd - indentStart;
-        val tabSize = editorSettings.getTabSize(project);
+        val editorSettings = settings
+        val indentSize = indentEnd - indentStart
+        val tabSize = editorSettings.getTabSize(project)
 
         if (!count) {
             if (editorSettings.isUseTabCharacter(project)) {
-                return indentSize * tabSize;
+                return indentSize * tabSize
             }
 
-            return indentSize;
-        };
-
-        if (editorSettings.isUseTabCharacter(project)) {
-            return indentSize;
+            return indentSize
         }
 
-        return indentSize / tabSize;
+        if (editorSettings.isUseTabCharacter(project)) {
+            return indentSize
+        }
+
+        return indentSize / tabSize
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/annotator/GdConstVarIdAnnotator.kt
+++ b/gdscript/src/main/kotlin/gdscript/annotator/GdConstVarIdAnnotator.kt
@@ -22,7 +22,7 @@ class GdConstVarIdAnnotator : Annotator {
                 is GdPattern -> return
             }
 
-            isUnique(element as GdNamedIdElement, holder);
+            isUnique(element as GdNamedIdElement, holder)
         }
     }
 
@@ -38,7 +38,7 @@ class GdConstVarIdAnnotator : Annotator {
                         HighlightSeverity.ERROR,
                         "[${element.name}] is already defined")
                 .range(element.textRange)
-                .create();
+                .create()
         }
     }
 

--- a/gdscript/src/main/kotlin/gdscript/annotator/GdLambdaAnnotator.kt
+++ b/gdscript/src/main/kotlin/gdscript/annotator/GdLambdaAnnotator.kt
@@ -19,7 +19,7 @@ class GdLambdaAnnotator : Annotator {
             .newSilentAnnotation(HighlightSeverity.INFORMATION)
             .range(element.textRange)
             .textAttributes(GdHighlighterColors.METHOD_DECLARATION)
-            .create();
+            .create()
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/annotator/GdMatchStmtAnnotator.kt
+++ b/gdscript/src/main/kotlin/gdscript/annotator/GdMatchStmtAnnotator.kt
@@ -23,34 +23,34 @@ class GdMatchStmtAnnotator : Annotator {
         val id = PsiTreeUtil.getDeepestLast(element).parent
         if (id !is GdRefIdRef) return
 
-        val rootDecl = GdClassMemberReference(id).resolveDeclaration() ?: return;
-        val typeHint = PsiTreeUtil.findChildrenOfType(rootDecl, GdTypeHintRef::class.java).lastOrNull() ?: return;
+        val rootDecl = GdClassMemberReference(id).resolveDeclaration() ?: return
+        val typeHint = PsiTreeUtil.findChildrenOfType(rootDecl, GdTypeHintRef::class.java).lastOrNull() ?: return
         val enumNmi = typeHint.resolveRef() ?: return
         // val enumNmi = GdTypeHintNmReference(typeHint).resolve() ?: return
-        if (enumNmi !is GdEnumDeclNmi) return;
+        if (enumNmi !is GdEnumDeclNmi) return
 
-        val match: GdMatchSt = element.parent as GdMatchSt;
+        val match: GdMatchSt = element.parent as GdMatchSt
         val usedKeys = PsiTreeUtil.findChildrenOfAnyType(match, GdPattern::class.java).map {
-            if (it.text == "_") return;
+            if (it.text == "_") return
             it.text
-        };
+        }
 
-        val enum = PsiTreeUtil.getStubOrPsiParent(enumNmi) as GdEnumDeclTl;
-        val allKeys = enum.values.toMutableMap();
+        val enum = PsiTreeUtil.getStubOrPsiParent(enumNmi) as GdEnumDeclTl
+        val allKeys = enum.values.toMutableMap()
 
-        var prefix = "";
-        val owningClassId = GdClassUtil.getOwningClassName(enum);
+        var prefix = ""
+        val owningClassId = GdClassUtil.getOwningClassName(enum)
 
         // Is it my own enum?
         if (!GdInheritanceUtil.isExtending(element, owningClassId)) {
-            val myId = GdClassUtil.getFullClassId(element);
+            val myId = GdClassUtil.getFullClassId(element)
             // InnerClass enum
             if ("$myId.$owningClassId" == GdClassUtil.getFullClassId(enum)) {
                 prefix = "$owningClassId."
             } else {
                 // Enum of outside class
-                val enumClass = GdClassUtil.getOwningClassElement(enum);
-                prefix = "${GdClassUtil.getFullClassId(enumClass)}.";
+                val enumClass = GdClassUtil.getOwningClassElement(enum)
+                prefix = "${GdClassUtil.getFullClassId(enumClass)}."
             }
         }
 
@@ -60,14 +60,14 @@ class GdMatchStmtAnnotator : Annotator {
             if (it.startsWith(prefix)) {
                 allKeys.remove(it.removePrefix(prefix))
             }
-        };
+        }
 
-        if (allKeys.isEmpty()) return;
+        if (allKeys.isEmpty()) return
         holder
             .newAnnotationGd(element.project, HighlightSeverity.WEAK_WARNING, "Missing enum options")
             .range(element.textRange)
             .withFix(GdAddMatchBranchesFix(match, allKeys.keys.map { "$prefix$it" }.toTypedArray()))
-            .create();
+            .create()
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/annotator/GdMethodNameAnnotator.kt
+++ b/gdscript/src/main/kotlin/gdscript/annotator/GdMethodNameAnnotator.kt
@@ -22,20 +22,20 @@ class GdMethodNameAnnotator : Annotator {
             .newSilentAnnotation(HighlightSeverity.INFORMATION)
             .range(element.textRange)
             .textAttributes(GdHighlighterColors.METHOD_DECLARATION)
-            .create();
+            .create()
 
-        isUnique(element, holder);
+        isUnique(element, holder)
     }
 
     private fun isUnique(element: GdMethodIdNmi, holder: AnnotationHolder) {
-        val name = element.name;
+        val name = element.name
 
         // Constructors
         if (GdClassUtil.getOwningClassName(element) == name) {
-            return;
+            return
         }
 
-        val declaration = GdClassMemberUtil.listLocalDeclarationsUpward(element)[name];
+        val declaration = GdClassMemberUtil.listLocalDeclarationsUpward(element)[name]
         if (declaration != null) {
             val type = when (declaration) {
                 is GdMethodDeclTl -> "method"
@@ -53,7 +53,7 @@ class GdMethodNameAnnotator : Annotator {
                         "Name [${element.name}] already defined as $type"
                 )
                 .range(element.textRange)
-                .create();
+                .create()
         }
     }
 

--- a/gdscript/src/main/kotlin/gdscript/codeInsight/GdInlayParameterHintProvider.kt
+++ b/gdscript/src/main/kotlin/gdscript/codeInsight/GdInlayParameterHintProvider.kt
@@ -32,7 +32,7 @@ class GdInlayParameterHintProvider : InlayParameterHintsProvider {
                     }
                 }
 
-                return MethodInfo(name, declaration.parameters.keys.toList());
+                return MethodInfo(name, declaration.parameters.keys.toList())
             } else if (declaration is GdVarDeclSt && declaration.expr is GdFuncDeclEx) {
                 // Lambdas
                 val lambda = declaration.expr as GdFuncDeclEx
@@ -62,25 +62,25 @@ class GdInlayParameterHintProvider : InlayParameterHintsProvider {
 
     override fun getParameterHints(element: PsiElement): List<InlayInfo> {
         if (element is GdCallEx) {
-            val id = PsiTreeUtil.findChildOfType(element, GdRefIdRef::class.java) ?: return emptyList();
+            val id = PsiTreeUtil.findChildOfType(element, GdRefIdRef::class.java) ?: return emptyList()
             val method = GdClassMemberReference(id).resolveDeclaration()
 
-            var params: Array<String> = emptyArray();
+            var params: Array<String> = emptyArray()
             when (method) {
                 is GdMethodDeclTl -> {
-                    params = method.parameters.keys.toArray(emptyArray());
+                    params = method.parameters.keys.toArray(emptyArray())
 
                     if (method.name == "emit") {
-                        val signal = PsiGdSignalUtil.getDeclaration(element);
+                        val signal = PsiGdSignalUtil.getDeclaration(element)
                         if (signal != null) {
-                            params = signal.parameters.keys.toArray(emptyArray());
+                            params = signal.parameters.keys.toArray(emptyArray())
                         }
                     }
                 }
 
                 is GdVarDeclSt -> {
                     if (method.expr is GdFuncDeclEx) {
-                        val lambda = method.expr as GdFuncDeclEx;
+                        val lambda = method.expr as GdFuncDeclEx
                         params = lambda.parameters.keys.toArray(emptyArray())
                     } else {
                         return emptyList()
@@ -100,7 +100,7 @@ class GdInlayParameterHintProvider : InlayParameterHintsProvider {
                         if (!hint.isConstructor) continue
                         val hints = hint.paramList?.paramList
                         if (hints == null || usedParams == null || hints.size != usedParams.size) continue
-                        var ok = true;
+                        var ok = true
                         for (i in 0 until hints.size) {
                             val t1 = usedParams[i].expr.returnType
                             val t2 = hints[i].returnType

--- a/gdscript/src/main/kotlin/gdscript/codeInsight/GdParameterInfoHandler.kt
+++ b/gdscript/src/main/kotlin/gdscript/codeInsight/GdParameterInfoHandler.kt
@@ -109,7 +109,7 @@ class GdParameterInfoHandler : ParameterInfoHandler<PsiElement, PsiElement>, Dum
             if (i > 0) {
                 builder.append(", ")
             }
-            val start = builder.length;
+            val start = builder.length
             builder.append("${it.key}: ${it.value}")
             if (currentParam == i) {
                 startOffset = start

--- a/gdscript/src/main/kotlin/gdscript/codeInsight/GdUsageProvider.kt
+++ b/gdscript/src/main/kotlin/gdscript/codeInsight/GdUsageProvider.kt
@@ -17,7 +17,7 @@ class GdUsageProvider : FindUsagesProvider {
             GdTokenTypeSet.IDENTIFIERS,
             GdTokenTypeSet.COMMENT,
             TokenSet.EMPTY,
-        );
+        )
     }
 
     override fun canFindUsagesFor(psiElement: PsiElement): Boolean {

--- a/gdscript/src/main/kotlin/gdscript/completion/GdInheritanceReferenceContributor.kt
+++ b/gdscript/src/main/kotlin/gdscript/completion/GdInheritanceReferenceContributor.kt
@@ -23,7 +23,7 @@ class GdInheritanceReferenceContributor : PsiReferenceContributor() {
                     return arrayOf(GdInheritanceReference(element))
                 }
             }
-        );
+        )
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/completion/GdLookup.kt
+++ b/gdscript/src/main/kotlin/gdscript/completion/GdLookup.kt
@@ -45,25 +45,25 @@ object GdLookup {
             .withIcon(icon)
 
         if (presentable !== null) {
-            builder = builder.withPresentableText(presentable);
+            builder = builder.withPresentableText(presentable)
         }
 
         if (handler !== null || lookup != null) {
-            builder = builder.withInsertHandler(handler ?: GdLookupInsertHandler.INSTANCE);
+            builder = builder.withInsertHandler(handler ?: GdLookupInsertHandler.INSTANCE)
         }
 
         if (color !== null) {
-            builder = builder.withItemTextForeground(color);
+            builder = builder.withItemTextForeground(color)
         }
 
         if (priority === null) {
-            return builder;
+            return builder
         }
 
         return PrioritizedLookupElement.withPriority(
             builder,
             priority,
-        );
+        )
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/completion/GdMethodDeclCompletionContributor.kt
+++ b/gdscript/src/main/kotlin/gdscript/completion/GdMethodDeclCompletionContributor.kt
@@ -16,12 +16,12 @@ import gdscript.utils.CompletionParametersUtil.indent
  */
 class GdMethodDeclCompletionContributor : CompletionContributor() {
 
-    val METHOD_ID = psiElement().withParent(psiElement(GdTypes.METHOD_ID_NMI));
+    val METHOD_ID = psiElement().withParent(psiElement(GdTypes.METHOD_ID_NMI))
 
     override fun fillCompletionVariants(parameters: CompletionParameters, result: CompletionResultSet) {
-        val element = parameters.originalPosition ?: return;
+        val element = parameters.originalPosition ?: return
         if (METHOD_ID.accepts(parameters.position)) {
-            val parent = GdInheritanceUtil.getExtendedElement(element) ?: return;
+            val parent = GdInheritanceUtil.getExtendedElement(element) ?: return
             val list = mutableListOf<Any>()
             GdClassMemberUtil.collectFromParents(parent, list, element.project)
             list

--- a/gdscript/src/main/kotlin/gdscript/completion/GdResourceCompletionContributor.kt
+++ b/gdscript/src/main/kotlin/gdscript/completion/GdResourceCompletionContributor.kt
@@ -18,9 +18,9 @@ import gdscript.psi.utils.GdNodeUtil
  */
 class GdResourceCompletionContributor : CompletionContributor() {
 
-    val NODE_PATH = psiElement(GdTypes.NODE_PATH_LEX);
-    val NODE_PATH_ROOT = NODE_PATH.withSuperParent(3, psiElement(GdFile::class.java));
-    val STRING = psiElement(GdTypes.STRING);
+    val NODE_PATH = psiElement(GdTypes.NODE_PATH_LEX)
+    val NODE_PATH_ROOT = NODE_PATH.withSuperParent(3, psiElement(GdFile::class.java))
+    val STRING = psiElement(GdTypes.STRING)
 
     override fun fillCompletionVariants(parameters: CompletionParameters, result: CompletionResultSet) {
         val r = result.withPrefixMatcher(CamelHumpMatcher(

--- a/gdscript/src/main/kotlin/gdscript/completion/GdSetGetMethodIdReferenceContributor.kt
+++ b/gdscript/src/main/kotlin/gdscript/completion/GdSetGetMethodIdReferenceContributor.kt
@@ -20,10 +20,10 @@ class GdSetGetMethodIdReferenceContributor : PsiReferenceContributor() {
             ),
             object : PsiReferenceProvider() {
                 override fun getReferencesByElement(element: PsiElement, context: ProcessingContext): Array<PsiReference> {
-                    return arrayOf(GdSetGetMethodIdReference(element));
+                    return arrayOf(GdSetGetMethodIdReference(element))
                 }
             }
-        );
+        )
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/completion/GdTypeHintCompletionContributor.kt
+++ b/gdscript/src/main/kotlin/gdscript/completion/GdTypeHintCompletionContributor.kt
@@ -16,7 +16,7 @@ class GdTypeHintCompletionContributor : CompletionContributor() {
     override fun fillCompletionVariants(parameters: CompletionParameters, result: CompletionResultSet) {
         if (GdRefIdCompletionUtil.DIRECT_REF.accepts(parameters.position)) {
             // RefId position offers built-ins like PI or INF
-            GdLiteralCompletionUtil.builtIns(result);
+            GdLiteralCompletionUtil.builtIns(result)
         }
     }
 

--- a/gdscript/src/main/kotlin/gdscript/completion/GdTypeHintReferenceContributor.kt
+++ b/gdscript/src/main/kotlin/gdscript/completion/GdTypeHintReferenceContributor.kt
@@ -23,7 +23,7 @@ class GdTypeHintReferenceContributor : PsiReferenceContributor() {
                     return arrayOf(GdTypeHintReference(element as GdTypeHintRef))
                 }
             }
-        );
+        )
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/completion/GetterSetterNameCompletion.kt
+++ b/gdscript/src/main/kotlin/gdscript/completion/GetterSetterNameCompletion.kt
@@ -21,21 +21,21 @@ class GetterSetterNameCompletion : CompletionContributor() {
 
     override fun fillCompletionVariants(parameters: CompletionParameters, result: CompletionResultSet) {
         if (SET_METHOD.accepts(parameters.position)) {
-            addMethodName("set", parameters.position, result);
+            addMethodName("set", parameters.position, result)
         } else if (GET_METHOD.accepts(parameters.position)) {
-            addMethodName("get", parameters.position, result);
+            addMethodName("get", parameters.position, result)
         }
     }
 
     private fun addMethodName(prefix: String, element: PsiElement, result: CompletionResultSet) {
-        val name = PsiTreeUtil.getStubOrPsiParentOfType(element, GdClassVarDeclTl::class.java)?.name ?: return;
+        val name = PsiTreeUtil.getStubOrPsiParentOfType(element, GdClassVarDeclTl::class.java)?.name ?: return
         result.addElement(
             GdLookup.create(
                 "_${prefix}_${name.trimStart('_')}",
                 priority = GdLookup.TOP,
                 icon = GdScriptPluginIcons.GDScriptIcons.METHOD_MARKER,
             )
-        );
+        )
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/completion/utils/GdClassCompletionUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/completion/utils/GdClassCompletionUtil.kt
@@ -15,11 +15,11 @@ object GdClassCompletionUtil {
     fun allRootClasses(project: Project): Array<LookupElement> {
         return GdClassNamingIndex.INSTANCE.getNonEmptyKeys(project).map {
             GdLookup.create(it, priority = GdLookup.USER_DEFINED, icon = GdIcon.getEditorIcon(it))
-        }.toTypedArray();
+        }.toTypedArray()
     }
 
     fun GdClassDeclTl.lookup(): LookupElement {
-        val name = this.name;
+        val name = this.name
         return GdLookup.create(name, priority = GdLookup.USER_DEFINED, icon = GdIcon.getEditorIcon(name))
     }
 

--- a/gdscript/src/main/kotlin/gdscript/completion/utils/GdClassVarCompletionUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/completion/utils/GdClassVarCompletionUtil.kt
@@ -22,7 +22,7 @@ object GdClassVarCompletionUtil {
                         color = GdLookup.COLOR_ANNOTATION,
                         priority = GdLookup.BUILT_IN,
                     )
-                );
+                )
         }
     }
 

--- a/gdscript/src/main/kotlin/gdscript/completion/utils/GdEnumCompletionUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/completion/utils/GdEnumCompletionUtil.kt
@@ -23,9 +23,9 @@ object GdEnumCompletionUtil {
     }
 
     fun lookup(element: GdEnumValue): LookupElement {
-        val decl = PsiTreeUtil.getParentOfType(element, GdEnumDeclTl::class.java);
-        val values = decl?.values;
-        val name = element.enumValueNmi.name;
+        val decl = PsiTreeUtil.getParentOfType(element, GdEnumDeclTl::class.java)
+        val values = decl?.values
+        val name = element.enumValueNmi.name
 
         return GdLookup.create(
             name,
@@ -39,7 +39,7 @@ object GdEnumCompletionUtil {
     }
 
     fun GdEnumDeclTl.lookup(): LookupElement? {
-        if (name.isBlank()) return null;
+        if (name.isBlank()) return null
 
         return GdLookup.create(
             name,

--- a/gdscript/src/main/kotlin/gdscript/completion/utils/GdMethodCompletionUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/completion/utils/GdMethodCompletionUtil.kt
@@ -30,8 +30,8 @@ object GdMethodCompletionUtil {
 
     fun addMethods(methods: Map<String, GdMethodDeclTl>, result: CompletionResultSet, withFunc: Boolean = false) {
         methods.forEach {
-            val item = it.value;
-            val params = buildParamHint(item);
+            val item = it.value
+            val params = buildParamHint(item)
             result.addElement(GdLookup.create(
                 "${if (withFunc) "func " else ""}${item.name}$params${if (item.returnType.isNotEmpty()) " -> ${item.returnType}" else ""}:",
                 tail = params,
@@ -44,7 +44,7 @@ object GdMethodCompletionUtil {
     }
 
     fun GdMethodDeclTl.lookup(): LookupElement {
-        val params = buildParamHint(this);
+        val params = buildParamHint(this)
         return GdLookup.create(
             this.name,
             tail = params,
@@ -55,7 +55,7 @@ object GdMethodCompletionUtil {
     }
 
     fun GdMethodDeclTl.lookupDeclaration(omitFuncKeyword: Boolean = false, indent: String? = null): LookupElement {
-        val params = buildParamHint(this);
+        val params = buildParamHint(this)
         return GdLookup.create(
             "${if (omitFuncKeyword) "" else "func "}${this.name}$params${if (this.returnType.isNotEmpty()) " -> ${this.returnType}" else ""}:${if (indent !== null) "\n$indent" else ""}",
             tail = params,
@@ -91,7 +91,7 @@ object GdMethodCompletionUtil {
         }
         if (wrap) sb.append("\n")
 
-        return sb.append(")").toString();
+        return sb.append(")").toString()
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/formatter/GdBraceMatcher.kt
+++ b/gdscript/src/main/kotlin/gdscript/formatter/GdBraceMatcher.kt
@@ -12,7 +12,7 @@ class GdBraceMatcher : PairedBraceMatcher {
         BracePair(GdTypes.LRBR, GdTypes.RRBR, true),
         BracePair(GdTypes.LCBR, GdTypes.RCBR, true),
         BracePair(GdTypes.LSBR, GdTypes.RSBR, true),
-    );
+    )
 
     override fun isPairedBracesAllowedBeforeType(lbraceType: IElementType, contextType: IElementType?): Boolean {
         return true

--- a/gdscript/src/main/kotlin/gdscript/formatter/GdFoldingBuilder.kt
+++ b/gdscript/src/main/kotlin/gdscript/formatter/GdFoldingBuilder.kt
@@ -39,22 +39,22 @@ class GdFoldingBuilder : FoldingBuilderEx(), DumbAware {
     }
 
     override fun isCollapsedByDefault(node: ASTNode): Boolean {
-        return false;
+        return false
     }
 
     private fun mapSuite(element: GdSuite): FoldingDescriptor? {
-        val ending = PsiTreeUtil.getDeepestVisibleLast(element) ?: return null;
-        if (ending.endOffset <= element.startOffset) return null;
+        val ending = PsiTreeUtil.getDeepestVisibleLast(element) ?: return null
+        if (ending.endOffset <= element.startOffset) return null
 
-        return FoldingDescriptor(element.node, TextRange(element.startOffset, ending.endOffset));
+        return FoldingDescriptor(element.node, TextRange(element.startOffset, ending.endOffset))
     }
 
     private fun mapClassDecl(element: GdClassDeclTl): FoldingDescriptor? {
-        val start = element.classNameNmi?.nextLeaf { it.elementType == GdTypes.COLON } ?: return null;
-        val ending = PsiTreeUtil.getDeepestVisibleLast(element) ?: return null;
-        if (ending.endOffset <= start.startOffset + 1) return null;
+        val start = element.classNameNmi?.nextLeaf { it.elementType == GdTypes.COLON } ?: return null
+        val ending = PsiTreeUtil.getDeepestVisibleLast(element) ?: return null
+        if (ending.endOffset <= start.startOffset + 1) return null
 
-        return FoldingDescriptor(element.node, TextRange(start.startOffset + 1, ending.endOffset));
+        return FoldingDescriptor(element.node, TextRange(start.startOffset + 1, ending.endOffset))
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/formatter/block/Alignments.kt
+++ b/gdscript/src/main/kotlin/gdscript/formatter/block/Alignments.kt
@@ -12,10 +12,10 @@ class Alignments {
         val ASSIGN = arrayOf(GdTypes.EQ, GdTypes.ASSIGN, GdTypes.ASSIGN_TYPED)
     }
 
-    var standard: Alignment? = null;
-    var after: Alignment? = null;
-    var settings: GdCodeStyleSettings;
-    var spaces = 0;
+    var standard: Alignment? = null
+    var after: Alignment? = null
+    var settings: GdCodeStyleSettings
+    var spaces = 0
 
     constructor(settings: GdCodeStyleSettings, standard: Alignment? = null, after: Alignment? = null) {
         this.standard = standard
@@ -24,9 +24,9 @@ class Alignments {
     }
 
     fun initialize() {
-        standard = Alignment.createAlignment(true);
-        after = Alignment.createAlignment(true);
-        spaces = 0;
+        standard = Alignment.createAlignment(true)
+        after = Alignment.createAlignment(true)
+        spaces = 0
     }
 
     /**
@@ -49,7 +49,7 @@ class Alignments {
             return Alignments(settings, standard, after)
         }
 
-        return Alignments(settings);
+        return Alignments(settings)
     }
 
     fun getAlignment(type: IElementType): Alignment? {

--- a/gdscript/src/main/kotlin/gdscript/formatter/block/GdAlignments.kt
+++ b/gdscript/src/main/kotlin/gdscript/formatter/block/GdAlignments.kt
@@ -20,12 +20,12 @@ object GdAlignments {
         // TODO match?
     )
 
-    var alignment: Alignment? = null;
-    var type: IElementType? = null;
+    var alignment: Alignment? = null
+    var type: IElementType? = null
 
     fun reset() {
-        alignment = null;
-        type = null;
+        alignment = null
+        type = null
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/formatter/settings/GdSettings.kt
+++ b/gdscript/src/main/kotlin/gdscript/formatter/settings/GdSettings.kt
@@ -14,7 +14,7 @@ object GdSettings {
                 Pair("SPACE_BEFORE_COLON", "Before :"),
             )
         ),
-    );
+    )
 
     val BLANK_LINES: HashMap<String, HashMap<String, String>> = hashMapOf(
         Pair(
@@ -33,7 +33,7 @@ object GdSettings {
                 Pair("LINES_BEFORE_FUNC_MIN", "Before func declaration"),
             )
         ),
-    );
+    )
 
     val WRAPPING_AND_BRACES: HashMap<String, HashMap<String, String>> = hashMapOf(
         Pair(
@@ -47,7 +47,7 @@ object GdSettings {
                 Pair("ALIGN_COMMENTS", "Align"),
             ),
         ),
-    );
+    )
 
     fun HashMap<String, HashMap<String, String>>.consume(consumer: CodeStyleSettingsCustomizable) {
         this.forEach { (group, fields) ->

--- a/gdscript/src/main/kotlin/gdscript/index/impl/utils/GdFileResDataExternalizer.kt
+++ b/gdscript/src/main/kotlin/gdscript/index/impl/utils/GdFileResDataExternalizer.kt
@@ -7,11 +7,11 @@ import java.io.DataOutput
 object GdFileResDataExternalizer : DataExternalizer<String> {
 
     override fun save(out: DataOutput, value: String) {
-        out.writeBytes(value);
+        out.writeBytes(value)
     }
 
     override fun read(`in`: DataInput): String {
-        return `in`.readLine();
+        return `in`.readLine()
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/index/stub/GdClassDeclStubImpl.kt
+++ b/gdscript/src/main/kotlin/gdscript/index/stub/GdClassDeclStubImpl.kt
@@ -20,11 +20,11 @@ class GdClassDeclStubImpl : StubBase<GdClassDeclTl>, GdClassDeclStub {
     }
 
     override fun name(): String {
-        return myClassname;
+        return myClassname
     }
 
     override fun parent(): String {
-        return myParentName;
+        return myParentName
     }
 
     override fun description(): String = this.doc.description

--- a/gdscript/src/main/kotlin/gdscript/index/stub/GdClassIdStub.kt
+++ b/gdscript/src/main/kotlin/gdscript/index/stub/GdClassIdStub.kt
@@ -4,6 +4,6 @@ import com.intellij.psi.stubs.StubElement
 import gdscript.psi.GdClassNameNmi
 
 interface GdClassIdStub : StubElement<GdClassNameNmi> {
-    fun name(): String;
-    fun parent(): String;
+    fun name(): String
+    fun parent(): String
 }

--- a/gdscript/src/main/kotlin/gdscript/index/stub/GdClassIdStubImpl.kt
+++ b/gdscript/src/main/kotlin/gdscript/index/stub/GdClassIdStubImpl.kt
@@ -7,20 +7,20 @@ import gdscript.psi.impl.GdClassIdElementType
 
 class GdClassIdStubImpl : StubBase<GdClassNameNmi>, GdClassIdStub {
 
-    private var myClassId: String = "";
-    private var myParentName: String = "";
+    private var myClassId: String = ""
+    private var myParentName: String = ""
 
     constructor(parent: StubElement<*>?, name: String, parentName: String?): super(parent, GdClassIdElementType) {
         this.myClassId = name
-        this.myParentName = parentName.orEmpty();
+        this.myParentName = parentName.orEmpty()
     }
 
     override fun name(): String {
-        return myClassId;
+        return myClassId
     }
 
     override fun parent(): String {
-        return myParentName;
+        return myParentName
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/index/stub/GdClassNamingStub.kt
+++ b/gdscript/src/main/kotlin/gdscript/index/stub/GdClassNamingStub.kt
@@ -4,6 +4,6 @@ import com.intellij.psi.stubs.StubElement
 import gdscript.psi.GdClassNaming
 
 interface GdClassNamingStub : StubElement<GdClassNaming> {
-    fun name(): String;
-    fun parent(): String;
+    fun name(): String
+    fun parent(): String
 }

--- a/gdscript/src/main/kotlin/gdscript/index/stub/GdClassNamingStubImpl.kt
+++ b/gdscript/src/main/kotlin/gdscript/index/stub/GdClassNamingStubImpl.kt
@@ -7,20 +7,20 @@ import gdscript.psi.impl.GdClassNamingElementType
 
 class GdClassNamingStubImpl : StubBase<GdClassNaming>, GdClassNamingStub {
 
-    private var myClassname: String = "";
-    private var myParentName: String = "";
+    private var myClassname: String = ""
+    private var myParentName: String = ""
 
     constructor(parent: StubElement<*>?, name: String, parentName: String?) : super(parent, GdClassNamingElementType) {
-        this.myClassname = name;
-        this.myParentName = parentName.orEmpty();
+        this.myClassname = name
+        this.myParentName = parentName.orEmpty()
     }
 
     override fun name(): String {
-        return myClassname;
+        return myClassname
     }
 
     override fun parent(): String {
-        return myParentName;
+        return myParentName
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/index/stub/GdClassVarDeclStubImpl.kt
+++ b/gdscript/src/main/kotlin/gdscript/index/stub/GdClassVarDeclStubImpl.kt
@@ -9,8 +9,8 @@ import gdscript.psi.impl.GdClassVarDeclElementType
 
 class GdClassVarDeclStubImpl : StubBase<GdClassVarDeclTl>, GdClassVarDeclStub {
 
-    private var name: String = "";
-    private var static: Boolean = false;
+    private var name: String = ""
+    private var static: Boolean = false
     private var doc: GdCommentModel
 
     constructor(parent: StubElement<*>?, name: String?, static: Boolean, doc: GdCommentModel): super(parent, GdClassVarDeclElementType) {

--- a/gdscript/src/main/kotlin/gdscript/index/stub/GdConstDeclStub.kt
+++ b/gdscript/src/main/kotlin/gdscript/index/stub/GdConstDeclStub.kt
@@ -5,5 +5,5 @@ import gdscript.psi.GdConstDeclTl
 import gdscript.psi.types.GdDocumented
 
 interface GdConstDeclStub : StubElement<GdConstDeclTl>, GdDocumented {
-    fun name(): String;
+    fun name(): String
 }

--- a/gdscript/src/main/kotlin/gdscript/index/stub/GdConstDeclStubImpl.kt
+++ b/gdscript/src/main/kotlin/gdscript/index/stub/GdConstDeclStubImpl.kt
@@ -8,18 +8,18 @@ import gdscript.psi.GdConstDeclTl
 import gdscript.psi.impl.GdConstDeclElementType
 
 class GdConstDeclStubImpl : StubBase<GdConstDeclTl>, GdConstDeclStub {
-    private var name: String = "";
+    private var name: String = ""
     private var doc: GdCommentModel
 
     constructor(parent: StubElement<*>?, name: String?, doc: GdCommentModel): super(parent, GdConstDeclElementType) {
         if (name != null) {
             this.name = name
-        };
+        }
         this.doc = doc
     }
 
     override fun name(): String {
-        return name;
+        return name
     }
 
     override fun description(): String = this.doc.description

--- a/gdscript/src/main/kotlin/gdscript/index/stub/GdInheritanceStub.kt
+++ b/gdscript/src/main/kotlin/gdscript/index/stub/GdInheritanceStub.kt
@@ -4,5 +4,5 @@ import com.intellij.psi.stubs.StubElement
 import gdscript.psi.GdInheritance
 
 interface GdInheritanceStub : StubElement<GdInheritance> {
-    fun inheritancePath(): String;
+    fun inheritancePath(): String
 }

--- a/gdscript/src/main/kotlin/gdscript/index/stub/GdInheritanceStubImpl.kt
+++ b/gdscript/src/main/kotlin/gdscript/index/stub/GdInheritanceStubImpl.kt
@@ -6,13 +6,13 @@ import gdscript.psi.GdInheritance
 import gdscript.psi.impl.GdInheritanceElementType
 
 class GdInheritanceStubImpl : StubBase<GdInheritance>, GdInheritanceStub {
-    private var inheritancePath: String = "";
+    private var inheritancePath: String = ""
 
     constructor(parent: StubElement<*>?, path: String): super(parent, GdInheritanceElementType) {
-        this.inheritancePath = path;
+        this.inheritancePath = path
     }
 
     override fun inheritancePath(): String {
-        return inheritancePath;
+        return inheritancePath
     }
 }

--- a/gdscript/src/main/kotlin/gdscript/index/stub/GdMethodDeclStub.kt
+++ b/gdscript/src/main/kotlin/gdscript/index/stub/GdMethodDeclStub.kt
@@ -5,10 +5,10 @@ import gdscript.psi.GdMethodDeclTl
 import gdscript.psi.types.GdDocumented
 
 interface GdMethodDeclStub : StubElement<GdMethodDeclTl>, GdDocumented {
-    fun isStatic(): Boolean;
-    fun isVariadic(): Boolean;
-    fun name(): String;
-    fun returnType(): String;
-    fun parameters(): LinkedHashMap<String, String?>;
-    fun isConstructor(): Boolean;
+    fun isStatic(): Boolean
+    fun isVariadic(): Boolean
+    fun name(): String
+    fun returnType(): String
+    fun parameters(): LinkedHashMap<String, String?>
+    fun isConstructor(): Boolean
 }

--- a/gdscript/src/main/kotlin/gdscript/index/stub/GdMethodDeclStubImpl.kt
+++ b/gdscript/src/main/kotlin/gdscript/index/stub/GdMethodDeclStubImpl.kt
@@ -9,12 +9,12 @@ import gdscript.psi.impl.GdMethodDeclElementType
 
 class GdMethodDeclStubImpl : StubBase<GdMethodDeclTl>, GdMethodDeclStub {
 
-    private var isStatic: Boolean = false;
-    private var isVariadic: Boolean = false;
-    private var name: String = "";
-    private var returnType: String = "";
-    private var isConstructor: Boolean = false;
-    private var parameters: LinkedHashMap<String, String?> = LinkedHashMap();
+    private var isStatic: Boolean = false
+    private var isVariadic: Boolean = false
+    private var name: String = ""
+    private var returnType: String = ""
+    private var isConstructor: Boolean = false
+    private var parameters: LinkedHashMap<String, String?> = LinkedHashMap()
     private var doc: GdCommentModel
 
     constructor(
@@ -29,26 +29,26 @@ class GdMethodDeclStubImpl : StubBase<GdMethodDeclTl>, GdMethodDeclStub {
     ) : super(parent, GdMethodDeclElementType) {
         if (name != null) {
             this.name = name
-        };
-        this.isStatic = isStatic;
-        this.isVariadic = isVariadic;
-        this.isConstructor = isConstructor;
-        this.returnType = returnType;
-        this.parameters = parameters;
+        }
+        this.isStatic = isStatic
+        this.isVariadic = isVariadic
+        this.isConstructor = isConstructor
+        this.returnType = returnType
+        this.parameters = parameters
         this.doc = doc
     }
 
-    override fun isStatic(): Boolean = isStatic;
+    override fun isStatic(): Boolean = isStatic
 
-    override fun isVariadic(): Boolean = isVariadic;
+    override fun isVariadic(): Boolean = isVariadic
 
-    override fun name(): String = name;
+    override fun name(): String = name
 
-    override fun returnType(): String = returnType;
+    override fun returnType(): String = returnType
 
-    override fun parameters(): LinkedHashMap<String, String?> = parameters;
+    override fun parameters(): LinkedHashMap<String, String?> = parameters
 
-    override fun isConstructor(): Boolean = isConstructor;
+    override fun isConstructor(): Boolean = isConstructor
 
     override fun description(): String = this.doc.description
     override fun brief(): String = this.doc.brief

--- a/gdscript/src/main/kotlin/gdscript/index/stub/GdSignalDeclStubImpl.kt
+++ b/gdscript/src/main/kotlin/gdscript/index/stub/GdSignalDeclStubImpl.kt
@@ -15,13 +15,13 @@ class GdSignalDeclStubImpl : StubBase<GdSignalDeclTl>, GdSignalDeclStub {
     constructor(parent: StubElement<*>?, name: String?, parameters: LinkedHashMap<String, String?>, doc: GdCommentModel): super(parent, GdSignalDeclElementType) {
         if (name != null) {
             this.name = name
-        };
+        }
         this.parameters = parameters
         this.doc = doc
     }
 
     override fun name(): String {
-        return name;
+        return name
     }
 
     override fun parameters(): LinkedHashMap<String, String?> {

--- a/gdscript/src/main/kotlin/gdscript/inspection/GdTypeHintInspection.kt
+++ b/gdscript/src/main/kotlin/gdscript/inspection/GdTypeHintInspection.kt
@@ -44,7 +44,7 @@ class GdTypeHintInspection : LocalInspectionTool() {
             else -> return
         }
 
-        val assigment = returnTypes.first;
+        val assigment = returnTypes.first
         // := assigment cannot specify the type
         if (assigment !== null && assigment.text.equals(":=")) {
             if (returnTypes.second === null) {
@@ -57,8 +57,8 @@ class GdTypeHintInspection : LocalInspectionTool() {
             return
         }
 
-        val returnType = returnTypes.second?.typedVal?.returnType;
-        val expr = returnTypes.third;
+        val returnType = returnTypes.second?.typedVal?.returnType
+        val expr = returnTypes.third
         if (returnType != null || expr == null) return
 
         val realType = expr.returnType

--- a/gdscript/src/main/kotlin/gdscript/inspection/GdUnusedSignalInspection.kt
+++ b/gdscript/src/main/kotlin/gdscript/inspection/GdUnusedSignalInspection.kt
@@ -20,7 +20,7 @@ class GdUnusedSignalInspection : GdUnusedInspection() {
                 // check for tscn references
                 if (TscnSignalSearcher(o.signalIdNmi!!, holder.project).anySignalReference()) return
 
-                registerUnused(o, o.signalIdNmi!!, holder);
+                registerUnused(o, o.signalIdNmi!!, holder)
             }
         }
     }

--- a/gdscript/src/main/kotlin/gdscript/inspection/validator/GdMethodValidationResult.kt
+++ b/gdscript/src/main/kotlin/gdscript/inspection/validator/GdMethodValidationResult.kt
@@ -19,6 +19,6 @@ data class GdMethodValidationResult(
     }
 
     fun voidOnlyReturn() : Boolean {
-        return returnTypes.isEmpty() || (returnTypes.size == 1 && returnTypes.contains(GdKeywords.VOID));
+        return returnTypes.isEmpty() || (returnTypes.size == 1 && returnTypes.contains(GdKeywords.VOID))
     }
 }

--- a/gdscript/src/main/kotlin/gdscript/inspection/validator/GdMethodValidator.kt
+++ b/gdscript/src/main/kotlin/gdscript/inspection/validator/GdMethodValidator.kt
@@ -116,7 +116,7 @@ class GdMethodValidator(val project : Project, val returnType: String) {
     }
 
     private fun checkReturnStatement(statement: GdFlowSt) {
-        val stmtType = statement.expr?.returnType ?: GdKeywords.VOID;
+        val stmtType = statement.expr?.returnType ?: GdKeywords.VOID
         if (!GdExprUtil.typeAccepts(stmtType, returnType, project)) {
             invalidReturns.add(Pair(statement, stmtType))
         }

--- a/gdscript/src/main/kotlin/gdscript/lineMarker/GdInheritanceLineMarkerContributor.kt
+++ b/gdscript/src/main/kotlin/gdscript/lineMarker/GdInheritanceLineMarkerContributor.kt
@@ -18,7 +18,7 @@ import javax.swing.Icon
 class GdInheritanceLineMarkerContributor : RelatedItemLineMarkerProvider() {
 
     override fun getIcon(): Icon? {
-        return GdScriptPluginIcons.GDScriptIcons.OVERRIDE;
+        return GdScriptPluginIcons.GDScriptIcons.OVERRIDE
     }
 
     override fun collectNavigationMarkers(

--- a/gdscript/src/main/kotlin/gdscript/lineMarker/GdResourceLineMarkerContributor.kt
+++ b/gdscript/src/main/kotlin/gdscript/lineMarker/GdResourceLineMarkerContributor.kt
@@ -21,7 +21,7 @@ class GdResourceLineMarkerContributor : RelatedItemLineMarkerProvider() {
         element: PsiElement,
         result: MutableCollection<in RelatedItemLineMarkerInfo<*>>,
     ) {
-        if (element.parent !is GdInheritanceIdRef || !GdInheritanceUtil.isExtending(element, "Resource")) return;
+        if (element.parent !is GdInheritanceIdRef || !GdInheritanceUtil.isExtending(element, "Resource")) return
 
         // TODO
 //        val usages = GdUserFileIndex.INSTANCE.resourceFiles(

--- a/gdscript/src/main/kotlin/gdscript/lineMarker/GdRunLineMarkerProvider.kt
+++ b/gdscript/src/main/kotlin/gdscript/lineMarker/GdRunLineMarkerProvider.kt
@@ -20,9 +20,9 @@ class GdRunLineMarkerProvider : RunLineMarkerContributor() {
             return null
         if (element.parent !is GdInheritanceIdRef || GdInheritanceUtil.isExtending(element, "Resource"))
             return null
-        if (GdInheritanceUtil.getExtendedElement(element) !is PsiFile) return null;
+        if (GdInheritanceUtil.getExtendedElement(element) !is PsiFile) return null
 
-        return Info(GdRunAction(element.parent as GdInheritanceIdRef));
+        return Info(GdRunAction(element.parent as GdInheritanceIdRef))
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/lineMarker/GdTscnLineMarkerContributor.kt
+++ b/gdscript/src/main/kotlin/gdscript/lineMarker/GdTscnLineMarkerContributor.kt
@@ -19,14 +19,14 @@ import javax.swing.Icon
 class GdTscnLineMarkerContributor : RelatedItemLineMarkerProvider() {
 
     override fun getIcon(): Icon? {
-        return GdScriptPluginIcons.GDScriptIcons.SLOT;
+        return GdScriptPluginIcons.GDScriptIcons.SLOT
     }
 
     override fun collectNavigationMarkers(
         element: PsiElement,
         result: MutableCollection<in RelatedItemLineMarkerInfo<*>>,
     ) {
-        if (element !is GdMethodIdNmi) return;
+        if (element !is GdMethodIdNmi) return
 
         val connections = TscnMethodSearcher(element, element.project).listMethodReferences()
         if (connections.isEmpty()) return

--- a/gdscript/src/main/kotlin/gdscript/psi/GdElementFactory.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/GdElementFactory.kt
@@ -27,7 +27,7 @@ object GdElementFactory {
     }
 
     fun enumValueNmi(project: Project, name: String): PsiElement {
-        val file = createFile(project, "extends Node\nenum Enum {$name = 1}\n");
+        val file = createFile(project, "extends Node\nenum Enum {$name = 1}\n")
 
         return PsiTreeUtil.findChildOfType(file, GdEnumValueNmi::class.java)!!.firstChild
     }
@@ -39,7 +39,7 @@ object GdElementFactory {
     }
 
     fun getMethodIdRef(project: Project, name: String): PsiElement {
-        val file = createFile(project, "extends Node\nvar variable:\n\tget = $name\n");
+        val file = createFile(project, "extends Node\nvar variable:\n\tget = $name\n")
 
         return PsiTreeUtil.findChildOfType(file, GdGetMethodIdRef::class.java)!!.firstChild
     }
@@ -122,7 +122,7 @@ object GdElementFactory {
     }
 
     fun callExpr(project: Project, expr: String): GdExpr {
-        val file = createFile(project, "extends Node\nfunc fu():\n\t$expr");
+        val file = createFile(project, "extends Node\nfunc fu():\n\t$expr")
 
         return PsiTreeUtil.findChildOfType(file, GdExpr::class.java)!!
     }

--- a/gdscript/src/main/kotlin/gdscript/psi/impl/GdClassDeclElementType.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/impl/GdClassDeclElementType.kt
@@ -17,7 +17,7 @@ object GdClassDeclElementType : IStubElementType<GdClassDeclStub, GdClassDeclTl>
      * @return name of extended class
      */
     fun getParentName(element: GdClassDeclTl): String {
-        val stub = element.stub;
+        val stub = element.stub
         if (stub !== null) {
             return stub.parent()
         }
@@ -55,7 +55,7 @@ object GdClassDeclElementType : IStubElementType<GdClassDeclStub, GdClassDeclTl>
         GdClassDeclTlImpl(stub, stub.stubType)
 
     override fun createStub(psi: GdClassDeclTl, parentStub: StubElement<*>?): GdClassDeclStub {
-        val inheritance = PsiTreeUtil.getStubChildOfType(psi, GdInheritance::class.java);
+        val inheritance = PsiTreeUtil.getStubChildOfType(psi, GdInheritance::class.java)
 
         return GdClassDeclStubImpl(
             parentStub,

--- a/gdscript/src/main/kotlin/gdscript/psi/impl/GdClassIdElementType.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/impl/GdClassIdElementType.kt
@@ -14,25 +14,25 @@ import gdscript.psi.utils.PsiGdTreeUtil
 object GdClassIdElementType : IStubElementType<GdClassIdStub, GdClassNameNmi>("gd.classId", GdLanguage) {
 
     fun getClassId(element: GdClassNameNmi): String {
-        val parents: MutableList<String> = mutableListOf();
-        var parent = PsiGdClassUtil.getParentClassElement(element);
+        val parents: MutableList<String> = mutableListOf()
+        var parent = PsiGdClassUtil.getParentClassElement(element)
         while (true) {
             if (parent is GdClassDeclTl) {
-                parents.add(parent.classNameNmi?.name.orEmpty());
+                parents.add(parent.classNameNmi?.name.orEmpty())
             } else if (parent is GdClassNaming) {
-                parents.add(parent.classNameNmi?.name.orEmpty());
-                break;
+                parents.add(parent.classNameNmi?.name.orEmpty())
+                break
             } else if (parent is GdFile) {
-                parents.add("\"${PsiGdResourceUtil.resourcePath(parent.virtualFile ?: parent.originalFile.virtualFile)}\"");
+                parents.add("\"${PsiGdResourceUtil.resourcePath(parent.virtualFile ?: parent.originalFile.virtualFile)}\"")
                 break
             } else {
                 break
             }
 
-            parent = PsiGdClassUtil.getParentClassElement(parent);
+            parent = PsiGdClassUtil.getParentClassElement(parent)
         }
 
-        return parents.reversed().joinToString(".");
+        return parents.reversed().joinToString(".")
     }
 
     @Deprecated("this should be at declaration, not here.. ?")
@@ -43,7 +43,7 @@ object GdClassIdElementType : IStubElementType<GdClassIdStub, GdClassNameNmi>("g
 
         val inh = PsiTreeUtil.findChildOfType(declaration, GdInheritance::class.java)
 
-        return inh?.inheritancePath;
+        return inh?.inheritancePath
     }
 
     @JvmStatic
@@ -54,12 +54,12 @@ object GdClassIdElementType : IStubElementType<GdClassIdStub, GdClassNameNmi>("g
     override fun getExternalId(): String = "GdScript.classId"
 
     override fun serialize(stub: GdClassIdStub, dataStream: StubOutputStream) {
-        dataStream.writeName(stub.name());
-        dataStream.writeName(stub.parent());
+        dataStream.writeName(stub.name())
+        dataStream.writeName(stub.parent())
     }
 
     override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?): GdClassIdStub {
-        return GdClassIdStubImpl(parentStub, dataStream.readNameString()!!, dataStream.readNameString());
+        return GdClassIdStubImpl(parentStub, dataStream.readNameString()!!, dataStream.readNameString())
     }
 
     override fun indexStub(stub: GdClassIdStub, sink: IndexSink) {
@@ -70,7 +70,7 @@ object GdClassIdElementType : IStubElementType<GdClassIdStub, GdClassNameNmi>("g
             GdClassNameNmiImpl(stub, stub.stubType)
 
     override fun createStub(psi: GdClassNameNmi, parentStub: StubElement<*>?): GdClassIdStub {
-        return GdClassIdStubImpl(parentStub, psi.classId, getParentName(psi));
+        return GdClassIdStubImpl(parentStub, psi.classId, getParentName(psi))
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/psi/impl/GdClassNamingElementType.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/impl/GdClassNamingElementType.kt
@@ -12,19 +12,19 @@ import gdscript.psi.GdInheritance
 object GdClassNamingElementType : IStubElementType<GdClassNamingStub, GdClassNaming>("classNaming", GdLanguage) {
 
     fun getClassname(element: GdClassNaming?): String {
-        return element?.classNameNmi?.name.toString();
+        return element?.classNameNmi?.name.toString()
     }
 
     /**
      * @return name of extended class
      */
     fun getParentName(element: GdClassNaming): String {
-        val stub = element.stub;
+        val stub = element.stub
         if (stub !== null) {
-            return stub.parent();
+            return stub.parent()
         }
 
-        return PsiTreeUtil.getStubChildOfType(element.parent, GdInheritance::class.java)?.inheritancePath.orEmpty();
+        return PsiTreeUtil.getStubChildOfType(element.parent, GdInheritance::class.java)?.inheritancePath.orEmpty()
     }
 
     @JvmStatic
@@ -35,12 +35,12 @@ object GdClassNamingElementType : IStubElementType<GdClassNamingStub, GdClassNam
     override fun getExternalId(): String = "GdScript.classNaming"
 
     override fun serialize(stub: GdClassNamingStub, dataStream: StubOutputStream) {
-        dataStream.writeName(stub.name());
-        dataStream.writeName(stub.parent());
+        dataStream.writeName(stub.name())
+        dataStream.writeName(stub.parent())
     }
 
     override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?): GdClassNamingStub {
-        return GdClassNamingStubImpl(parentStub, dataStream.readNameString().orEmpty(), dataStream.readName()?.string);
+        return GdClassNamingStubImpl(parentStub, dataStream.readNameString().orEmpty(), dataStream.readName()?.string)
     }
 
     override fun indexStub(stub: GdClassNamingStub, sink: IndexSink) {
@@ -51,7 +51,7 @@ object GdClassNamingElementType : IStubElementType<GdClassNamingStub, GdClassNam
             GdClassNamingImpl(stub, stub.stubType)
 
     override fun createStub(psi: GdClassNaming, parentStub: StubElement<*>?): GdClassNamingStub {
-        val inheritance = PsiTreeUtil.getStubChildOfType(psi, GdInheritance::class.java);
+        val inheritance = PsiTreeUtil.getStubChildOfType(psi, GdInheritance::class.java)
 
         return GdClassNamingStubImpl(parentStub, psi.classNameNmi?.name.orEmpty(), inheritance?.inheritancePath)
     }

--- a/gdscript/src/main/kotlin/gdscript/psi/impl/GdClassVarDeclElementType.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/impl/GdClassVarDeclElementType.kt
@@ -16,7 +16,7 @@ object GdClassVarDeclElementType : IStubElementType<GdClassVarDeclStub, GdClassV
         return GdClassVarDeclElementType
     }
 
-    override fun getExternalId(): String = "GdScript.classVarDecl";
+    override fun getExternalId(): String = "GdScript.classVarDecl"
 
     override fun serialize(stub: GdClassVarDeclStub, dataStream: StubOutputStream) {
         dataStream.writeName(stub.name())

--- a/gdscript/src/main/kotlin/gdscript/psi/impl/GdConstDeclElementType.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/impl/GdConstDeclElementType.kt
@@ -13,10 +13,10 @@ object GdConstDeclElementType : IStubElementType<GdConstDeclStub, GdConstDeclTl>
 
     @JvmStatic
     fun getInstance(@Suppress("UNUSED_PARAMETER") debugName: String): GdConstDeclElementType {
-        return GdConstDeclElementType;
+        return GdConstDeclElementType
     }
 
-    override fun getExternalId(): String = "GdScript.constDecl";
+    override fun getExternalId(): String = "GdScript.constDecl"
 
     override fun serialize(stub: GdConstDeclStub, dataStream: StubOutputStream) {
         dataStream.writeName(stub.name())
@@ -30,11 +30,11 @@ object GdConstDeclElementType : IStubElementType<GdConstDeclStub, GdConstDeclTl>
         )
 
     override fun indexStub(stub: GdConstDeclStub, sink: IndexSink) {
-        sink.occurrence(Indices.CONST_DECL, stub.name());
+        sink.occurrence(Indices.CONST_DECL, stub.name())
     }
 
     override fun createPsi(stub: GdConstDeclStub): GdConstDeclTl =
-        GdConstDeclTlImpl(stub, stub.stubType);
+        GdConstDeclTlImpl(stub, stub.stubType)
 
     override fun createStub(psi: GdConstDeclTl, parentStub: StubElement<*>?): GdConstDeclStub {
         return GdConstDeclStubImpl(

--- a/gdscript/src/main/kotlin/gdscript/psi/impl/GdEnumDeclElementType.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/impl/GdEnumDeclElementType.kt
@@ -15,10 +15,10 @@ object GdEnumDeclElementType : IStubElementType<GdEnumDeclStub, GdEnumDeclTl>("e
 
     @JvmStatic
     fun getInstance(@Suppress("UNUSED_PARAMETER") debugName: String): GdEnumDeclElementType {
-        return GdEnumDeclElementType;
+        return GdEnumDeclElementType
     }
 
-    override fun getExternalId(): String = "GdScript.enumDecl";
+    override fun getExternalId(): String = "GdScript.enumDecl"
 
     override fun serialize(stub: GdEnumDeclStub, dataStream: StubOutputStream) {
         dataStream.writeName(stub.name())
@@ -32,23 +32,23 @@ object GdEnumDeclElementType : IStubElementType<GdEnumDeclStub, GdEnumDeclTl>("e
             dataStream.readNameString(),
             PsiGdEnumUtil.fromString(dataStream.readNameString()),
             GdCommentModel(dataStream),
-        );
+        )
 
     override fun indexStub(stub: GdEnumDeclStub, sink: IndexSink) {
-        var name: String? = stub.name();
+        var name: String? = stub.name()
         // TODO losos
         if (name == null || name.isEmpty()) {
-            name = stub.values().keys.firstOrNull();
+            name = stub.values().keys.firstOrNull()
         }
         if (name == null || name.isEmpty()) {
-            name = createSecureRandom().toString();
+            name = createSecureRandom().toString()
         }
 
-        sink.occurrence(Indices.ENUM, name);
+        sink.occurrence(Indices.ENUM, name)
     }
 
     override fun createPsi(stub: GdEnumDeclStub): GdEnumDeclTl =
-        GdEnumDeclTlImpl(stub, stub.stubType);
+        GdEnumDeclTlImpl(stub, stub.stubType)
 
     override fun createStub(psi: GdEnumDeclTl, parentStub: StubElement<*>?): GdEnumDeclStub {
         return GdEnumDeclStubImpl(

--- a/gdscript/src/main/kotlin/gdscript/psi/impl/GdInheritanceElementType.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/impl/GdInheritanceElementType.kt
@@ -21,21 +21,21 @@ object GdInheritanceElementType : IStubElementType<GdInheritanceStub, GdInherita
     override fun getExternalId(): String = "GdScript.inheritance"
 
     override fun serialize(stub: GdInheritanceStub, dataStream: StubOutputStream) {
-        dataStream.writeName(stub.inheritancePath());
+        dataStream.writeName(stub.inheritancePath())
     }
 
     override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?): GdInheritanceStub =
-        GdInheritanceStubImpl(parentStub, dataStream.readNameString().orEmpty());
+        GdInheritanceStubImpl(parentStub, dataStream.readNameString().orEmpty())
 
     override fun indexStub(stub: GdInheritanceStub, sink: IndexSink) {
-        sink.occurrence(Indices.INHERITANCE, stub.inheritancePath());
+        sink.occurrence(Indices.INHERITANCE, stub.inheritancePath())
     }
 
     override fun createPsi(stub: GdInheritanceStub): GdInheritance =
-        GdInheritanceImpl(stub, stub.stubType);
+        GdInheritanceImpl(stub, stub.stubType)
 
     override fun createStub(psi: GdInheritance, parentStub: StubElement<*>?): GdInheritanceStub {
-        return GdInheritanceStubImpl(parentStub, psi.inheritanceId?.text.orEmpty());
+        return GdInheritanceStubImpl(parentStub, psi.inheritanceId?.text.orEmpty())
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/psi/impl/GdMethodDeclElementType.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/impl/GdMethodDeclElementType.kt
@@ -14,10 +14,10 @@ object GdMethodDeclElementType : IStubElementType<GdMethodDeclStub, GdMethodDecl
 
     @JvmStatic
     fun getInstance(@Suppress("UNUSED_PARAMETER") debugName: String): GdMethodDeclElementType {
-        return GdMethodDeclElementType;
+        return GdMethodDeclElementType
     }
 
-    override fun getExternalId(): String = "GdScript.methodDecl";
+    override fun getExternalId(): String = "GdScript.methodDecl"
 
     override fun serialize(stub: GdMethodDeclStub, dataStream: StubOutputStream) {
         dataStream.writeBoolean(stub.isStatic())
@@ -39,14 +39,14 @@ object GdMethodDeclElementType : IStubElementType<GdMethodDeclStub, GdMethodDecl
             dataStream.readNameString() ?: "",
             PsiGdParameterUtil.fromString(dataStream.readNameString()),
             GdCommentModel(dataStream),
-        );
+        )
 
     override fun indexStub(stub: GdMethodDeclStub, sink: IndexSink) {
-        sink.occurrence(Indices.METHOD_DECL, stub.name());
+        sink.occurrence(Indices.METHOD_DECL, stub.name())
     }
 
     override fun createPsi(stub: GdMethodDeclStub): GdMethodDeclTl =
-        GdMethodDeclTlImpl(stub, stub.stubType);
+        GdMethodDeclTlImpl(stub, stub.stubType)
 
     override fun createStub(psi: GdMethodDeclTl, parentStub: StubElement<*>?): GdMethodDeclStub {
         GdCommentUtil.collectComments(psi)

--- a/gdscript/src/main/kotlin/gdscript/psi/impl/GdNamedIdElementImpl.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/impl/GdNamedIdElementImpl.kt
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.NotNull
 abstract class GdNamedIdElementImpl(node: @NotNull ASTNode) : ASTWrapperPsiElement(node), GdNamedIdElement {
 
     override fun getReferences(): Array<PsiReference> {
-        return ReferenceProvidersRegistryImpl.getReferencesFromProviders(this);
+        return ReferenceProvidersRegistryImpl.getReferencesFromProviders(this)
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/psi/impl/GdSignalDeclElementType.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/impl/GdSignalDeclElementType.kt
@@ -17,7 +17,7 @@ object GdSignalDeclElementType : IStubElementType<GdSignalDeclStub, GdSignalDecl
         return GdSignalDeclElementType
     }
 
-    override fun getExternalId(): String = "GdScript.signalDecl";
+    override fun getExternalId(): String = "GdScript.signalDecl"
 
     override fun serialize(stub: GdSignalDeclStub, dataStream: StubOutputStream) {
         dataStream.writeName(stub.name())

--- a/gdscript/src/main/kotlin/gdscript/psi/utils/GdClassUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/utils/GdClassUtil.kt
@@ -49,13 +49,13 @@ object GdClassUtil {
      */
     fun getOwningClassName(element: PsiElement): String {
         return when (val it = getOwningClassElement(element)) {
-            is GdClassDeclTl -> it.name;
+            is GdClassDeclTl -> it.name
             else -> {
-                val cln = PsiTreeUtil.getStubChildOfType(it, GdClassNaming::class.java);
-                if (cln != null) return cln.classname;
+                val cln = PsiTreeUtil.getStubChildOfType(it, GdClassNaming::class.java)
+                if (cln != null) return cln.classname
 
                 (element.containingFile.virtualFile ?: element.containingFile.originalFile.virtualFile)
-                    .resourcePath();
+                    .resourcePath()
             }
         }
     }
@@ -68,7 +68,7 @@ object GdClassUtil {
         return when (element) {
             is GdClassDeclTl -> element.classNameNmi?.classId ?: ""
             is GdFile -> {
-                val named = PsiTreeUtil.getStubChildOfType(element, GdClassNaming::class.java);
+                val named = PsiTreeUtil.getStubChildOfType(element, GdClassNaming::class.java)
                 if (named != null) {
                     named.classNameNmi?.classId ?: ""
                 } else {
@@ -97,7 +97,7 @@ object GdClassUtil {
     }
 
     fun getName(element: GdClassDeclTl): String {
-        val stub = element.stub;
+        val stub = element.stub
         if (stub != null) return stub.name()
 
         return element.classNameNmi?.name.orEmpty()

--- a/gdscript/src/main/kotlin/gdscript/psi/utils/GdConstDeclUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/utils/GdConstDeclUtil.kt
@@ -6,18 +6,18 @@ import gdscript.psi.GdConstDeclTl
 object GdConstDeclUtil {
 
     fun getName(element: GdConstDeclTl): String {
-        val stub = element.stub;
+        val stub = element.stub
         if (stub !== null) {
-            return stub.name();
+            return stub.name()
         }
 
-        return element.varNmi?.name.orEmpty();
+        return element.varNmi?.name.orEmpty()
     }
 
     /** Local */
 
     fun getName(element: GdConstDeclSt): String {
-        return element.varNmi?.name ?: "";
+        return element.varNmi?.name ?: ""
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/psi/utils/GdEnumUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/utils/GdEnumUtil.kt
@@ -5,10 +5,10 @@ import gdscript.psi.GdEnumDeclTl
 object GdEnumUtil {
 
     fun getName(element: GdEnumDeclTl): String {
-        val stub = element.stub;
-        if (stub != null) return stub.name();
+        val stub = element.stub
+        if (stub != null) return stub.name()
 
-        return element.enumDeclNmi?.name.orEmpty();
+        return element.enumDeclNmi?.name.orEmpty()
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/psi/utils/GdFileUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/utils/GdFileUtil.kt
@@ -10,7 +10,7 @@ object GdFileUtil {
 
     fun listTraits(project: Project): List<VirtualFile> {
         return FileTypeIndex.getFiles(GdFileType, GlobalSearchScope.allScope(project))
-            .filter { it.nameWithoutExtension.lowercase().endsWith("trait") };
+            .filter { it.nameWithoutExtension.lowercase().endsWith("trait") }
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/psi/utils/GdInheritanceUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/utils/GdInheritanceUtil.kt
@@ -41,7 +41,7 @@ object GdInheritanceUtil {
             getExtendedClassId(element),
             element,
             element.project,
-        );
+        )
     }
 
     /**
@@ -55,13 +55,13 @@ object GdInheritanceUtil {
     }
 
     fun isExtending(element: PsiElement, className: String): Boolean {
-        if (GdClassUtil.getOwningClassName(element) == className) return true;
+        if (GdClassUtil.getOwningClassName(element) == className) return true
 
-        var parentId = getExtendedClassId(element);
+        var parentId = getExtendedClassId(element)
         while (parentId.isNotBlank()) {
-            if (parentId == className) return true;
-            val parent = GdClassIdIndex.INSTANCE.getGlobally(parentId, element).firstOrNull() ?: return false;
-            parentId = getExtendedClassId(parent);
+            if (parentId == className) return true
+            val parent = GdClassIdIndex.INSTANCE.getGlobally(parentId, element).firstOrNull() ?: return false
+            parentId = getExtendedClassId(parent)
         }
 
         return false
@@ -73,20 +73,20 @@ object GdInheritanceUtil {
      * @return GdClassDeclTL|GdFile
      */
     fun getExtendedElement(classId: String, element: PsiElement, project: Project): PsiElement? {
-        val classEl = GdClassUtil.getClassIdElement(classId, element, project);
+        val classEl = GdClassUtil.getClassIdElement(classId, element, project)
         // Extending directly named class (includes "res://Item.gd".InnerClass)
         if (classEl != null) {
             return if (classEl.parent is GdClassDeclTl) {
-                classEl.parent;
+                classEl.parent
             } else {
-                classEl.containingFile;
+                classEl.containingFile
             }
         }
 
         // In case of unnamed "res://Item.gd" check for the resource itself
-        val file = GdFileResIndex.getFiles(classId.trim('"', '\''), project).firstOrNull() ?: return null;
+        val file = GdFileResIndex.getFiles(classId.trim('"', '\''), project).firstOrNull() ?: return null
 
-        return file.getPsiFile(project);
+        return file.getPsiFile(project)
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/psi/utils/GdMethodUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/utils/GdMethodUtil.kt
@@ -29,10 +29,10 @@ object GdMethodUtil {
     }
 
     fun getName(element: GdMethodDeclTl): String {
-        val stub = element.stub;
-        if (stub !== null) stub.name();
+        val stub = element.stub
+        if (stub !== null) stub.name()
 
-        return element.methodIdNmi?.name.orEmpty();
+        return element.methodIdNmi?.name.orEmpty()
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/psi/utils/GdNodeUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/utils/GdNodeUtil.kt
@@ -28,7 +28,7 @@ object GdNodeUtil {
             .split(":")
             .first()
 
-        return nodes.find { it.relativePath.trim('$') == path || it.uniqueId?.trim('%') == path };
+        return nodes.find { it.relativePath.trim('$') == path || it.uniqueId?.trim('%') == path }
     }
 
     /**

--- a/gdscript/src/main/kotlin/gdscript/psi/utils/GdSignalUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/utils/GdSignalUtil.kt
@@ -5,10 +5,10 @@ import gdscript.psi.GdSignalDeclTl
 object GdSignalUtil {
 
     fun getName(element: GdSignalDeclTl): String {
-        val stub = element.stub;
-        if (stub !== null) return stub.name();
+        val stub = element.stub
+        if (stub !== null) return stub.name()
 
-        return element.signalIdNmi?.name ?: "";
+        return element.signalIdNmi?.name ?: ""
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/psi/utils/GdStmtUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/utils/GdStmtUtil.kt
@@ -8,7 +8,7 @@ import gdscript.psi.GdWhileSt
 object GdStmtUtil {
 
     fun getType(element: GdFlowSt): String {
-        return element.firstChild.text;
+        return element.firstChild.text
     }
 
     fun isLoopStatement(stmt: GdStmt): Boolean {

--- a/gdscript/src/main/kotlin/gdscript/psi/utils/PsiGdClassUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/utils/PsiGdClassUtil.kt
@@ -10,14 +10,14 @@ import gdscript.psi.GdTypes
 object PsiGdClassUtil {
 
     fun getName(element: GdClassNameNmi?): String {
-        if (element == null) return "";
+        if (element == null) return ""
 
         val valueNode = element.node.findChildByType(GdTypes.IDENTIFIER)
         return valueNode?.text ?: ""
     }
 
     fun isInner(element: GdClassNameNmi): Boolean {
-        return element.parent is GdClassDeclTl;
+        return element.parent is GdClassDeclTl
     }
 
     /**

--- a/gdscript/src/main/kotlin/gdscript/psi/utils/PsiGdClassVarUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/utils/PsiGdClassVarUtil.kt
@@ -11,10 +11,10 @@ object PsiGdClassVarUtil {
 
     fun getReturnType(element: GdClassVarDeclTl): String {
         if (element.typed !== null) {
-            return PsiGdExprUtil.fromTyped(element.typed);
+            return PsiGdExprUtil.fromTyped(element.typed)
         }
 
-        return element.expr?.returnType ?: "";
+        return element.expr?.returnType ?: ""
     }
 
     fun isAnnotated(element: GdClassVarDeclTl, annotator: String): Boolean {

--- a/gdscript/src/main/kotlin/gdscript/psi/utils/PsiGdConstDeclUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/utils/PsiGdConstDeclUtil.kt
@@ -6,10 +6,10 @@ object PsiGdConstDeclUtil {
 
     fun getReturnType(element: GdConstDeclTl): String {
         if (element.typed !== null) {
-            return PsiGdExprUtil.fromTyped(element.typed);
+            return PsiGdExprUtil.fromTyped(element.typed)
         }
 
-        return element.expr?.returnType ?: "";
+        return element.expr?.returnType ?: ""
     }
 
 

--- a/gdscript/src/main/kotlin/gdscript/psi/utils/PsiGdInheritanceUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/utils/PsiGdInheritanceUtil.kt
@@ -16,12 +16,12 @@ object PsiGdInheritanceUtil {
     fun getPsiFile(inheritance: GdInheritanceIdRef): PsiFile? {
         val key = inheritance.text.trim('"', '\'')
         if (key.startsWith("res://")) {
-            val virtual = GdFileResIndex.getFiles(key, inheritance.project).first();
+            val virtual = GdFileResIndex.getFiles(key, inheritance.project).first()
 
-            return virtual.getPsiFile(inheritance.project);
+            return virtual.getPsiFile(inheritance.project)
         }
 
-        return GdClassNamingIndex.INSTANCE.getGlobally(inheritance).firstOrNull()?.containingFile;
+        return GdClassNamingIndex.INSTANCE.getGlobally(inheritance).firstOrNull()?.containingFile
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/psi/utils/PsiGdLocalConstUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/utils/PsiGdLocalConstUtil.kt
@@ -7,10 +7,10 @@ object PsiGdLocalConstUtil {
 
     fun getReturnType(element: GdConstDeclSt): String {
         if (element.typed !== null) {
-            return PsiGdExprUtil.fromTyped(element.typed);
+            return PsiGdExprUtil.fromTyped(element.typed)
         }
 
-        return element.expr?.returnType ?: "";
+        return element.expr?.returnType ?: ""
     }
 
     fun getReturnExpr(element: GdConstDeclSt): PsiElement? {

--- a/gdscript/src/main/kotlin/gdscript/psi/utils/PsiGdLocalFuncUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/utils/PsiGdLocalFuncUtil.kt
@@ -7,7 +7,7 @@ import gdscript.psi.GdFuncDeclEx
 object PsiGdLocalFuncUtil {
 
     fun getReturnType(element: GdFuncDeclEx): String {
-        return element.returnHint?.returnHintVal?.text ?: "";
+        return element.returnHint?.returnHintVal?.text ?: ""
     }
 
     fun getReturnExpr(element: GdFuncDeclEx): PsiElement? {
@@ -15,7 +15,7 @@ object PsiGdLocalFuncUtil {
     }
 
     fun getParameters(element: GdFuncDeclEx): LinkedHashMap<String, String?> {
-        return PsiGdParameterUtil.toHashMap(element.paramList);
+        return PsiGdParameterUtil.toHashMap(element.paramList)
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/psi/utils/PsiGdLocalVarUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/utils/PsiGdLocalVarUtil.kt
@@ -6,10 +6,10 @@ object PsiGdLocalVarUtil {
 
     fun getReturnType(element: GdVarDeclSt): String {
         if (element.typed !== null) {
-            return PsiGdExprUtil.fromTyped(element.typed);
+            return PsiGdExprUtil.fromTyped(element.typed)
         }
 
-        return element.expr?.returnType ?: "";
+        return element.expr?.returnType ?: ""
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/psi/utils/PsiGdParameterUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/utils/PsiGdParameterUtil.kt
@@ -7,32 +7,32 @@ import java.lang.StringBuilder
 object PsiGdParameterUtil {
 
     fun fromString(data: String?): LinkedHashMap<String, String?> {
-        val params = LinkedHashMap<String, String?>();
+        val params = LinkedHashMap<String, String?>()
         if (data == null) {
-            return params;
+            return params
         }
 
         data.trim('{', '}').split(' ').forEach {
-            val parts = it.split('=');
+            val parts = it.split('=')
             if (parts.size == 2) {
-                params[parts[0]] = if (parts[1] == "null") null else parts[1].trim(' ', ',');
+                params[parts[0]] = if (parts[1] == "null") null else parts[1].trim(' ', ',')
             }
         }
 
-        return params;
+        return params
     }
 
     fun toHashMap(paramList: GdParamList?): LinkedHashMap<String, String?> {
-        val params = LinkedHashMap<String, String?>();
-        var child = paramList?.firstChild;
+        val params = LinkedHashMap<String, String?>()
+        var child = paramList?.firstChild
         while (child != null) {
             if (child is GdParam) {
                 params[child.varNmi.text] = PsiGdExprUtil.fromTyped(child.typed)
             }
-            child = child.nextSibling;
+            child = child.nextSibling
         }
 
-        return params;
+        return params
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/psi/utils/PsiGdResourceUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/utils/PsiGdResourceUtil.kt
@@ -6,7 +6,7 @@ import java.io.File
 
 object PsiGdResourceUtil {
 
-    val SEPARATOR = "/";
+    val SEPARATOR = "/"
 
     @Deprecated("VirtualFileUtil")
     fun resourcePath(file: VirtualFile, withPrefix: Boolean = true): String {

--- a/gdscript/src/main/kotlin/gdscript/psi/utils/PsiGdSignalUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/utils/PsiGdSignalUtil.kt
@@ -9,24 +9,24 @@ import gdscript.psi.GdSignalDeclTl
 object PsiGdSignalUtil {
 
     fun getParameters(element: GdSignalDeclTl): LinkedHashMap<String, String?> {
-        val stub = element.stub;
+        val stub = element.stub
         if (stub !== null) {
-            return stub.parameters();
+            return stub.parameters()
         }
 
         return PsiGdParameterUtil.toHashMap(element.paramList)
     }
 
     fun getDeclaration(element: GdCallEx): GdSignalDeclTl? {
-        val root = element.prevSibling?.prevSibling ?: return null;
-        if (root !is GdLiteralEx) return null;
+        val root = element.prevSibling?.prevSibling ?: return null
+        if (root !is GdLiteralEx) return null
 
-        val signalName = root.text;
-        val file = PsiGdExprUtil.getAttrOrCallParentFile(root) ?: element.containingFile;
+        val signalName = root.text
+        val file = PsiGdExprUtil.getAttrOrCallParentFile(root) ?: element.containingFile
 
         return GdSignalDeclIndex.INSTANCE
             .get(signalName, element.project, GlobalSearchScope.fileScope(file))
-            .firstOrNull();
+            .firstOrNull()
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/psi/utils/PsiGdTreeUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/psi/utils/PsiGdTreeUtil.kt
@@ -9,7 +9,7 @@ object PsiGdTreeUtil {
     fun findFirstPrecedingElement(element: PsiElement, withSelf: Boolean = true, condition: Condition<in PsiElement?>): PsiElement? {
         var el: PsiElement? = element
         if (!withSelf) {
-            el = el?.prevSibling ?: el?.parent;
+            el = el?.prevSibling ?: el?.parent
         }
 
         while (el != null) {

--- a/gdscript/src/main/kotlin/gdscript/run/GdConfigurationFactory.kt
+++ b/gdscript/src/main/kotlin/gdscript/run/GdConfigurationFactory.kt
@@ -13,6 +13,6 @@ object GdConfigurationFactory : ConfigurationFactory(GdRunConfigurationType.INST
         GdRunConfiguration(project, this, "GdScript")
 
     override fun getOptionsClass(): Class<out BaseState?> =
-        GdRunConfigurationOptions::class.java;
+        GdRunConfigurationOptions::class.java
 
 }

--- a/gdscript/src/main/kotlin/gdscript/structureView/GdPresentationUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/structureView/GdPresentationUtil.kt
@@ -10,33 +10,33 @@ object GdPresentationUtil {
 
     fun presentation(classVar: GdClassVarDeclTl): ItemPresentation {
         return object : ItemPresentation {
-            override fun getPresentableText(): String = classVar.name;
-            override fun getLocationString(): String = classVar.returnType;
-            override fun getIcon(unused: Boolean): Icon? = GdScriptPluginIcons.GDScriptIcons.VAR_MARKER;
+            override fun getPresentableText(): String = classVar.name
+            override fun getLocationString(): String = classVar.returnType
+            override fun getIcon(unused: Boolean): Icon? = GdScriptPluginIcons.GDScriptIcons.VAR_MARKER
         }
     }
 
     fun presentation(constVar: GdConstDeclTl): ItemPresentation {
         return object : ItemPresentation {
-            override fun getPresentableText(): String = constVar.name;
-            override fun getLocationString(): String = constVar.returnType;
-            override fun getIcon(unused: Boolean): Icon? = GdScriptPluginIcons.GDScriptIcons.CONST_MARKER;
+            override fun getPresentableText(): String = constVar.name
+            override fun getLocationString(): String = constVar.returnType
+            override fun getIcon(unused: Boolean): Icon? = GdScriptPluginIcons.GDScriptIcons.CONST_MARKER
         }
     }
 
     fun presentation(method: GdMethodDeclTl): ItemPresentation {
         return object : ItemPresentation {
-            override fun getPresentableText(): String? = method.name;
-            override fun getLocationString(): String = method.returnType;
-            override fun getIcon(unused: Boolean): Icon? = GdScriptPluginIcons.GDScriptIcons.METHOD_MARKER;
+            override fun getPresentableText(): String? = method.name
+            override fun getLocationString(): String = method.returnType
+            override fun getIcon(unused: Boolean): Icon? = GdScriptPluginIcons.GDScriptIcons.METHOD_MARKER
         }
     }
 
     fun presentation(enum: GdEnumDeclTl): ItemPresentation {
         return object : ItemPresentation {
-            override fun getPresentableText(): String = enum.enumDeclNmi?.name ?: "(${enum.values.firstOrNull()?.key}, ...)";
-            override fun getLocationString(): String = GdKeywords.INT;
-            override fun getIcon(unused: Boolean): Icon? = GdScriptPluginIcons.GDScriptIcons.ENUM_MARKER;
+            override fun getPresentableText(): String = enum.enumDeclNmi?.name ?: "(${enum.values.firstOrNull()?.key}, ...)"
+            override fun getLocationString(): String = GdKeywords.INT
+            override fun getIcon(unused: Boolean): Icon? = GdScriptPluginIcons.GDScriptIcons.ENUM_MARKER
         }
     }
 

--- a/gdscript/src/main/kotlin/gdscript/structureView/GdStructureViewElement.kt
+++ b/gdscript/src/main/kotlin/gdscript/structureView/GdStructureViewElement.kt
@@ -11,50 +11,50 @@ import gdscript.psi.*
 
 class GdStructureViewElement : StructureViewTreeElement, SortableTreeElement {
 
-    private var myElement: NavigatablePsiElement;
+    private var myElement: NavigatablePsiElement
 
     constructor(element: NavigatablePsiElement) {
         myElement = element
     }
 
-    override fun getPresentation(): ItemPresentation = myElement.presentation ?: PresentationData();
+    override fun getPresentation(): ItemPresentation = myElement.presentation ?: PresentationData()
 
     override fun getChildren(): Array<TreeElement> {
         val elements = mutableListOf<TreeElement>()
         if (myElement is GdFile) {
-            val consts = PsiTreeUtil.getChildrenOfTypeAsList(myElement, GdConstDeclTl::class.java);
+            val consts = PsiTreeUtil.getChildrenOfTypeAsList(myElement, GdConstDeclTl::class.java)
             elements.addAll(consts.map {
                 GdStructureViewElement(it as NavigatablePsiElement)
             })
 
-            val variables = PsiTreeUtil.getChildrenOfTypeAsList(myElement, GdClassVarDeclTl::class.java);
+            val variables = PsiTreeUtil.getChildrenOfTypeAsList(myElement, GdClassVarDeclTl::class.java)
             elements.addAll(variables.map {
                 GdStructureViewElement(it as NavigatablePsiElement)
             })
 
-            val enums = PsiTreeUtil.getChildrenOfTypeAsList(myElement, GdEnumDeclTl::class.java);
+            val enums = PsiTreeUtil.getChildrenOfTypeAsList(myElement, GdEnumDeclTl::class.java)
             elements.addAll(enums.map {
                 GdStructureViewElement(it as NavigatablePsiElement)
             })
 
-            val methods = PsiTreeUtil.getChildrenOfTypeAsList(myElement, GdMethodDeclTl::class.java);
+            val methods = PsiTreeUtil.getChildrenOfTypeAsList(myElement, GdMethodDeclTl::class.java)
             elements.addAll(methods.map {
                 GdStructureViewElement(it as NavigatablePsiElement)
             })
         }
 
-        return elements.toTypedArray();
+        return elements.toTypedArray()
     }
 
     override fun navigate(requestFocus: Boolean) {
-        myElement.navigate(requestFocus);
+        myElement.navigate(requestFocus)
     }
 
-    override fun canNavigate(): Boolean = myElement.canNavigate();
+    override fun canNavigate(): Boolean = myElement.canNavigate()
 
-    override fun canNavigateToSource(): Boolean = myElement.canNavigateToSource();
+    override fun canNavigateToSource(): Boolean = myElement.canNavigateToSource()
 
-    override fun getValue(): Any = myElement;
+    override fun getValue(): Any = myElement
 
     override fun getAlphaSortKey(): String = myElement.name ?: ""
 

--- a/gdscript/src/main/kotlin/gdscript/structureView/GdStructureViewModel.kt
+++ b/gdscript/src/main/kotlin/gdscript/structureView/GdStructureViewModel.kt
@@ -15,11 +15,11 @@ class GdStructureViewModel : StructureViewModelBase, StructureViewModel.ElementI
     constructor(psiFile: PsiFile) : super(psiFile, GdStructureViewElement(psiFile))
 
     override fun getSorters(): Array<Sorter> {
-        return arrayOf(Sorter.ALPHA_SORTER);
+        return arrayOf(Sorter.ALPHA_SORTER)
     }
 
     override fun isAlwaysShowsPlus(element: StructureViewTreeElement?): Boolean {
-        return false;
+        return false
     }
 
     override fun isAlwaysLeaf(element: StructureViewTreeElement): Boolean {

--- a/gdscript/src/main/kotlin/gdscript/utils/ElementTypeUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/utils/ElementTypeUtil.kt
@@ -11,13 +11,13 @@ object ElementTypeUtil {
     val SKIP_TOKEN = arrayOf(GdTypes.COMMENT, TokenType.WHITE_SPACE)
 
     fun hasChildOfType(element: PsiElement, elementType: IElementType): Boolean {
-        var child = element.firstChild;
+        var child = element.firstChild
         while (child != null) {
-            if (child.elementType == elementType) return true;
-            child = child.nextSibling;
+            if (child.elementType == elementType) return true
+            child = child.nextSibling
         }
 
-        return false;
+        return false
     }
 
     fun IElementType?.isSkipable(): Boolean {

--- a/gdscript/src/main/kotlin/gdscript/utils/GdCommentUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/utils/GdCommentUtil.kt
@@ -43,7 +43,7 @@ object GdCommentUtil {
      * Usages of Trait
      */
     fun listUsages(resource: String, project: Project): Array<PsiComment> {
-        val manager = PsiManager.getInstance(project);
+        val manager = PsiManager.getInstance(project)
 
         return FileTypeIndex.getFiles(GdFileType, GlobalSearchScope.allScope(project))
             .flatMap<VirtualFile, PsiComment> { file ->
@@ -54,7 +54,7 @@ object GdCommentUtil {
                     it.text.trim() == "${GdTraitLineMarkerContributor.PREFIX}$resource"
                 }
             }
-            .toTypedArray();
+            .toTypedArray()
     }
 
 }

--- a/gdscript/src/main/kotlin/gdscript/utils/PsiElementUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/utils/PsiElementUtil.kt
@@ -15,7 +15,7 @@ import project.psi.model.GdAutoload
 
 object PsiElementUtil {
 
-    private val SKIPS_TO_COMMENT = listOf(TokenType.WHITE_SPACE, GdTypes.INDENT, GdTypes.DEDENT);
+    private val SKIPS_TO_COMMENT = listOf(TokenType.WHITE_SPACE, GdTypes.INDENT, GdTypes.DEDENT)
 
     fun PsiElement.precedingNewLines(position: Int): Int {
         val parent = this.parent ?: return 0

--- a/gdscript/src/main/kotlin/gdscript/utils/StringUtil.kt
+++ b/gdscript/src/main/kotlin/gdscript/utils/StringUtil.kt
@@ -43,11 +43,11 @@ object StringUtil {
     }
 
     fun String.parseFromSquare(): String {
-        val start = this.indexOf('[');
-        val end = this.indexOf(']', start);
+        val start = this.indexOf('[')
+        val end = this.indexOf(']', start)
 
-        if (start < 0 || end < 1) return "";
-        return this.substring(start + 1, end);
+        if (start < 0 || end < 1) return ""
+        return this.substring(start + 1, end)
     }
 
     fun String.isDynamicType(): Boolean {

--- a/gdscript/src/main/kotlin/project/ProjectKeywords.kt
+++ b/gdscript/src/main/kotlin/project/ProjectKeywords.kt
@@ -3,9 +3,9 @@ package project
 object ProjectKeywords {
 
     /** Sections */
-    const val SECTION_BASE = ""; // base has no section key - thus use empty string
-    const val SECTION_AUTOLOADS = "autoload"; // Gg="*res://Gg.gd"
-    const val SECTION_INPUTS = "input";
-    const val SECTION_APPLICATION = "application";
+    const val SECTION_BASE = "" // base has no section key - thus use empty string
+    const val SECTION_AUTOLOADS = "autoload" // Gg="*res://Gg.gd"
+    const val SECTION_INPUTS = "input"
+    const val SECTION_APPLICATION = "application"
 
 }

--- a/gdscript/src/main/kotlin/project/ProjectLexerAdapter.kt
+++ b/gdscript/src/main/kotlin/project/ProjectLexerAdapter.kt
@@ -4,6 +4,6 @@ import com.intellij.lexer.FlexAdapter
 
 class ProjectLexerAdapter : FlexAdapter {
 
-    constructor() : super(ProjectLexer(null));
+    constructor() : super(ProjectLexer(null))
 
 }

--- a/gdscript/src/main/kotlin/project/ProjectParserDefinition.kt
+++ b/gdscript/src/main/kotlin/project/ProjectParserDefinition.kt
@@ -20,25 +20,25 @@ import project.psi.ProjectTypes
 class ProjectParserDefinition : ParserDefinition {
 
     companion object {
-        val WHITE_SPACES = TokenSet.create(TokenType.WHITE_SPACE);
-        val COMMENTS = TokenSet.create(ProjectTypes.COMMENT);
-        val FILE = IStubFileElementType<PsiFileStub<ProjectFile>>("GdScriptProjectFile", ProjectLanguage);
+        val WHITE_SPACES = TokenSet.create(TokenType.WHITE_SPACE)
+        val COMMENTS = TokenSet.create(ProjectTypes.COMMENT)
+        val FILE = IStubFileElementType<PsiFileStub<ProjectFile>>("GdScriptProjectFile", ProjectLanguage)
     }
 
-    override fun getWhitespaceTokens(): TokenSet = WHITE_SPACES;
+    override fun getWhitespaceTokens(): TokenSet = WHITE_SPACES
 
-    override fun createLexer(project: Project?): Lexer = ProjectLexerAdapter();
+    override fun createLexer(project: Project?): Lexer = ProjectLexerAdapter()
 
-    override fun createParser(project: Project?): PsiParser = ProjectParser();
+    override fun createParser(project: Project?): PsiParser = ProjectParser()
 
-    override fun getFileNodeType(): IFileElementType = FILE;
+    override fun getFileNodeType(): IFileElementType = FILE
 
-    override fun getCommentTokens(): TokenSet = COMMENTS;
+    override fun getCommentTokens(): TokenSet = COMMENTS
 
-    override fun getStringLiteralElements(): TokenSet = TokenSet.EMPTY;
+    override fun getStringLiteralElements(): TokenSet = TokenSet.EMPTY
 
-    override fun createElement(node: ASTNode?): PsiElement = ProjectTypes.Factory.createElement(node);
+    override fun createElement(node: ASTNode?): PsiElement = ProjectTypes.Factory.createElement(node)
 
-    override fun createFile(viewProvider: FileViewProvider): PsiFile = ProjectFile(viewProvider);
+    override fun createFile(viewProvider: FileViewProvider): PsiFile = ProjectFile(viewProvider)
 
 }

--- a/gdscript/src/main/kotlin/project/index/impl/utils/GdFileResDataExternalizer.kt
+++ b/gdscript/src/main/kotlin/project/index/impl/utils/GdFileResDataExternalizer.kt
@@ -7,11 +7,11 @@ import java.io.DataOutput
 object GdFileResDataExternalizer : DataExternalizer<String> {
 
     override fun save(out: DataOutput, value: String) {
-        out.writeBytes(value);
+        out.writeBytes(value)
     }
 
     override fun read(`in`: DataInput): String {
-        return `in`.readLine();
+        return `in`.readLine()
     }
 
 }

--- a/gdscript/src/main/kotlin/project/index/stub/ProjectDataStub.kt
+++ b/gdscript/src/main/kotlin/project/index/stub/ProjectDataStub.kt
@@ -5,6 +5,6 @@ import project.psi.ProjectData
 
 interface ProjectDataStub : StubElement<ProjectData> {
 
-    fun getKey(): String;
+    fun getKey(): String
 
 }

--- a/gdscript/src/main/kotlin/project/index/stub/ProjectDataStubImpl.kt
+++ b/gdscript/src/main/kotlin/project/index/stub/ProjectDataStubImpl.kt
@@ -7,14 +7,14 @@ import project.psi.impl.ProjectDataElementType
 
 class ProjectDataStubImpl : StubBase<ProjectData>, ProjectDataStub {
 
-    private var key: String = "";
+    private var key: String = ""
 
     constructor(parent: StubElement<*>?, key: String) : super(parent, ProjectDataElementType) {
-        this.key = key;
+        this.key = key
     }
 
     override fun getKey(): String {
-        return key;
+        return key
     }
 
 }

--- a/gdscript/src/main/kotlin/project/index/stub/ProjectSectionStub.kt
+++ b/gdscript/src/main/kotlin/project/index/stub/ProjectSectionStub.kt
@@ -5,6 +5,6 @@ import project.psi.ProjectSection
 
 interface ProjectSectionStub : StubElement<ProjectSection> {
 
-    fun getName(): String;
+    fun getName(): String
 
 }

--- a/gdscript/src/main/kotlin/project/index/stub/ProjectSectionStubImpl.kt
+++ b/gdscript/src/main/kotlin/project/index/stub/ProjectSectionStubImpl.kt
@@ -7,14 +7,14 @@ import project.psi.impl.ProjectSectionElementType
 
 class ProjectSectionStubImpl : StubBase<ProjectSection>, ProjectSectionStub {
 
-    private var name: String = "";
+    private var name: String = ""
 
     constructor(parent: StubElement<*>?, name: String) : super(parent, ProjectSectionElementType) {
-        this.name = name;
+        this.name = name
     }
 
     override fun getName(): String {
-        return name;
+        return name
     }
 
 }

--- a/gdscript/src/main/kotlin/project/psi/ProjectElementType.kt
+++ b/gdscript/src/main/kotlin/project/psi/ProjectElementType.kt
@@ -5,6 +5,6 @@ import project.ProjectLanguage
 
 class ProjectElementType : IElementType {
 
-    constructor(debugName: String) : super(debugName, ProjectLanguage);
+    constructor(debugName: String) : super(debugName, ProjectLanguage)
 
 }

--- a/gdscript/src/main/kotlin/project/psi/ProjectFile.kt
+++ b/gdscript/src/main/kotlin/project/psi/ProjectFile.kt
@@ -10,7 +10,7 @@ class ProjectFile : PsiFileBase {
 
     constructor(viewProvider: FileViewProvider) : super(viewProvider, ProjectLanguage)
 
-    override fun getFileType(): FileType = ProjectFileType;
+    override fun getFileType(): FileType = ProjectFileType
 
     override fun toString(): String = "Godot's project file"
 

--- a/gdscript/src/main/kotlin/project/psi/ProjectPsiUtils.kt
+++ b/gdscript/src/main/kotlin/project/psi/ProjectPsiUtils.kt
@@ -6,10 +6,10 @@ import project.psi.util.ProjectSectionUtil
 object ProjectPsiUtils {
 
     /** Section */
-    @JvmStatic fun getName(element: ProjectSection): String = ProjectSectionUtil.getName(element);
+    @JvmStatic fun getName(element: ProjectSection): String = ProjectSectionUtil.getName(element)
 
     /** Data */
-    @JvmStatic fun getKey(element: ProjectData): String = ProjectDataUtil.getKey(element);
-    @JvmStatic fun getValue(element: ProjectData): String = ProjectDataUtil.getValue(element);
+    @JvmStatic fun getKey(element: ProjectData): String = ProjectDataUtil.getKey(element)
+    @JvmStatic fun getValue(element: ProjectData): String = ProjectDataUtil.getValue(element)
 
 }

--- a/gdscript/src/main/kotlin/project/psi/ProjectTokenType.kt
+++ b/gdscript/src/main/kotlin/project/psi/ProjectTokenType.kt
@@ -5,7 +5,7 @@ import project.ProjectLanguage
 
 class ProjectTokenType : IElementType {
 
-    constructor(debugName: String) : super(debugName, ProjectLanguage);
+    constructor(debugName: String) : super(debugName, ProjectLanguage)
 
     override fun toString(): String = "ProjectTokenType.${super.toString()}"
 

--- a/gdscript/src/main/kotlin/project/psi/impl/ProjectDataElementType.kt
+++ b/gdscript/src/main/kotlin/project/psi/impl/ProjectDataElementType.kt
@@ -16,7 +16,7 @@ object ProjectDataElementType : IStubElementType<ProjectDataStub, ProjectData>("
     override fun getExternalId(): String = "project.data"
 
     override fun serialize(stub: ProjectDataStub, dataStream: StubOutputStream) {
-        dataStream.writeName(stub.getKey());
+        dataStream.writeName(stub.getKey())
     }
 
     override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?): ProjectDataStub =
@@ -26,13 +26,13 @@ object ProjectDataElementType : IStubElementType<ProjectDataStub, ProjectData>("
         )
 
     override fun indexStub(stub: ProjectDataStub, sink: IndexSink) {
-        sink.occurrence(ProjectIndices.DATA_INDEX, stub.getKey());
+        sink.occurrence(ProjectIndices.DATA_INDEX, stub.getKey())
     }
 
     override fun createPsi(stub: ProjectDataStub): ProjectData =
-        ProjectDataImpl(stub, stub.stubType);
+        ProjectDataImpl(stub, stub.stubType)
 
     override fun createStub(psi: ProjectData, parentStub: StubElement<out PsiElement>?): ProjectDataStub =
-        ProjectDataStubImpl(parentStub, psi.key);
+        ProjectDataStubImpl(parentStub, psi.key)
 
 }

--- a/gdscript/src/main/kotlin/project/psi/impl/ProjectSectionElementType.kt
+++ b/gdscript/src/main/kotlin/project/psi/impl/ProjectSectionElementType.kt
@@ -16,7 +16,7 @@ object ProjectSectionElementType : IStubElementType<ProjectSectionStub, ProjectS
     override fun getExternalId(): String = "project.section"
 
     override fun serialize(stub: ProjectSectionStub, dataStream: StubOutputStream) {
-        dataStream.writeName(stub.getName());
+        dataStream.writeName(stub.getName())
     }
 
     override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?): ProjectSectionStub =
@@ -26,13 +26,13 @@ object ProjectSectionElementType : IStubElementType<ProjectSectionStub, ProjectS
         )
 
     override fun indexStub(stub: ProjectSectionStub, sink: IndexSink) {
-        sink.occurrence(ProjectIndices.SECTION_INDEX, stub.getName());
+        sink.occurrence(ProjectIndices.SECTION_INDEX, stub.getName())
     }
 
     override fun createPsi(stub: ProjectSectionStub): ProjectSection =
-        ProjectSectionImpl(stub, stub.stubType);
+        ProjectSectionImpl(stub, stub.stubType)
 
     override fun createStub(psi: ProjectSection, parentStub: StubElement<out PsiElement>?): ProjectSectionStub =
-        ProjectSectionStubImpl(parentStub, psi.name);
+        ProjectSectionStubImpl(parentStub, psi.name)
 
 }

--- a/gdscript/src/main/kotlin/project/psi/util/ProjectDataUtil.kt
+++ b/gdscript/src/main/kotlin/project/psi/util/ProjectDataUtil.kt
@@ -5,14 +5,14 @@ import project.psi.ProjectData
 object ProjectDataUtil {
 
     fun getKey(element: ProjectData): String {
-        val stub = element.stub;
-        if (stub != null) return stub.getKey();
+        val stub = element.stub
+        if (stub != null) return stub.getKey()
 
-        return element.dataKey.text;
+        return element.dataKey.text
     }
 
     fun getValue(element: ProjectData): String {
-        return element.dataValue.text;
+        return element.dataValue.text
     }
 
 }

--- a/gdscript/src/main/kotlin/project/psi/util/ProjectSectionUtil.kt
+++ b/gdscript/src/main/kotlin/project/psi/util/ProjectSectionUtil.kt
@@ -5,10 +5,10 @@ import project.psi.ProjectSection
 object ProjectSectionUtil {
 
     fun getName(element: ProjectSection): String {
-        val stub = element.stub;
-        if (stub != null) return stub.getName();
+        val stub = element.stub
+        if (stub != null) return stub.getName()
 
-        return element.sectionNm?.text ?: "";
+        return element.sectionNm?.text ?: ""
     }
 
 }

--- a/gdscript/src/main/kotlin/tscn/TscnLexerAdapter.kt
+++ b/gdscript/src/main/kotlin/tscn/TscnLexerAdapter.kt
@@ -4,6 +4,6 @@ import com.intellij.lexer.FlexAdapter
 
 class TscnLexerAdapter : FlexAdapter {
 
-    constructor() : super(TscnLexer(null));
+    constructor() : super(TscnLexer(null))
 
 }

--- a/gdscript/src/main/kotlin/tscn/TscnParserDefinition.kt
+++ b/gdscript/src/main/kotlin/tscn/TscnParserDefinition.kt
@@ -20,25 +20,25 @@ import tscn.psi.TscnTypes
 class TscnParserDefinition : ParserDefinition {
 
     companion object {
-        val WHITE_SPACES = TokenSet.create(TokenType.WHITE_SPACE);
-        val COMMENTS = TokenSet.create(TscnTypes.COMMENT);
-        val FILE = IStubFileElementType<PsiFileStub<TscnFile>>("GdScriptTscnFile", TscnLanguage);
+        val WHITE_SPACES = TokenSet.create(TokenType.WHITE_SPACE)
+        val COMMENTS = TokenSet.create(TscnTypes.COMMENT)
+        val FILE = IStubFileElementType<PsiFileStub<TscnFile>>("GdScriptTscnFile", TscnLanguage)
     }
 
-    override fun getWhitespaceTokens(): TokenSet = WHITE_SPACES;
+    override fun getWhitespaceTokens(): TokenSet = WHITE_SPACES
 
-    override fun createLexer(project: Project?): Lexer = TscnLexerAdapter();
+    override fun createLexer(project: Project?): Lexer = TscnLexerAdapter()
 
-    override fun createParser(project: Project?): PsiParser = TscnParser();
+    override fun createParser(project: Project?): PsiParser = TscnParser()
 
-    override fun getFileNodeType(): IFileElementType = FILE;
+    override fun getFileNodeType(): IFileElementType = FILE
 
-    override fun getCommentTokens(): TokenSet = COMMENTS;
+    override fun getCommentTokens(): TokenSet = COMMENTS
 
-    override fun getStringLiteralElements(): TokenSet = TokenSet.EMPTY;
+    override fun getStringLiteralElements(): TokenSet = TokenSet.EMPTY
 
-    override fun createElement(node: ASTNode?): PsiElement = TscnTypes.Factory.createElement(node);
+    override fun createElement(node: ASTNode?): PsiElement = TscnTypes.Factory.createElement(node)
 
-    override fun createFile(viewProvider: FileViewProvider): PsiFile = TscnFile(viewProvider);
+    override fun createFile(viewProvider: FileViewProvider): PsiFile = TscnFile(viewProvider)
 
 }

--- a/gdscript/src/main/kotlin/tscn/index/impl/TscnConnectionIndex.kt
+++ b/gdscript/src/main/kotlin/tscn/index/impl/TscnConnectionIndex.kt
@@ -11,10 +11,10 @@ class TscnConnectionIndex : StringStubIndexExtensionExt<TscnConnectionHeader>() 
         val INSTANCE = TscnConnectionIndex()
     }
 
-    override fun getKey(): StubIndexKey<String, TscnConnectionHeader> = TscnIndices.CONNECTION_INDEX;
+    override fun getKey(): StubIndexKey<String, TscnConnectionHeader> = TscnIndices.CONNECTION_INDEX
 
     override fun getVersion(): Int {
-        return TscnIndices.VERSION;
+        return TscnIndices.VERSION
     }
 
 }

--- a/gdscript/src/main/kotlin/tscn/index/impl/TscnNodeIndex.kt
+++ b/gdscript/src/main/kotlin/tscn/index/impl/TscnNodeIndex.kt
@@ -11,7 +11,7 @@ class TscnNodeIndex : StringStubIndexExtensionExt<TscnNodeHeader>() {
         val INSTANCE = TscnNodeIndex()
     }
 
-    override fun getKey(): StubIndexKey<String, TscnNodeHeader> = TscnIndices.NODE_INDEX;
+    override fun getKey(): StubIndexKey<String, TscnNodeHeader> = TscnIndices.NODE_INDEX
 
     override fun getVersion(): Int {
         return TscnIndices.VERSION

--- a/gdscript/src/main/kotlin/tscn/index/impl/TscnParagraphIndex.kt
+++ b/gdscript/src/main/kotlin/tscn/index/impl/TscnParagraphIndex.kt
@@ -11,10 +11,10 @@ class TscnParagraphIndex : StringStubIndexExtensionExt<TscnParagraph>() {
         val INSTANCE = TscnParagraphIndex()
     }
 
-    override fun getKey(): StubIndexKey<String, TscnParagraph> = TscnIndices.PARAGRAPH_INDEX;
+    override fun getKey(): StubIndexKey<String, TscnParagraph> = TscnIndices.PARAGRAPH_INDEX
 
     override fun getVersion(): Int {
-        return TscnIndices.VERSION;
+        return TscnIndices.VERSION
     }
 
 }

--- a/gdscript/src/main/kotlin/tscn/index/impl/TscnResourceIndex.kt
+++ b/gdscript/src/main/kotlin/tscn/index/impl/TscnResourceIndex.kt
@@ -11,10 +11,10 @@ class TscnResourceIndex : StringStubIndexExtensionExt<TscnResourceHeader>() {
         val INSTANCE = TscnResourceIndex()
     }
 
-    override fun getKey(): StubIndexKey<String, TscnResourceHeader> = TscnIndices.RESOURCE_INDEX;
+    override fun getKey(): StubIndexKey<String, TscnResourceHeader> = TscnIndices.RESOURCE_INDEX
 
     override fun getVersion(): Int {
-        return TscnIndices.VERSION;
+        return TscnIndices.VERSION
     }
 
 }

--- a/gdscript/src/main/kotlin/tscn/index/stub/TscnConnectionHeaderStub.kt
+++ b/gdscript/src/main/kotlin/tscn/index/stub/TscnConnectionHeaderStub.kt
@@ -5,9 +5,9 @@ import tscn.psi.TscnConnectionHeader
 
 interface TscnConnectionHeaderStub : StubElement<TscnConnectionHeader> {
 
-    fun getFrom(): String;
-    fun getTo(): String;
-    fun getMethod(): String;
-    fun getSignal(): String;
+    fun getFrom(): String
+    fun getTo(): String
+    fun getMethod(): String
+    fun getSignal(): String
 
 }

--- a/gdscript/src/main/kotlin/tscn/index/stub/TscnConnectionHeaderStubImpl.kt
+++ b/gdscript/src/main/kotlin/tscn/index/stub/TscnConnectionHeaderStubImpl.kt
@@ -7,32 +7,32 @@ import tscn.psi.impl.TscnConnectionHeaderElementType
 
 class TscnConnectionHeaderStubImpl : StubBase<TscnConnectionHeader>, TscnConnectionHeaderStub {
 
-    private var from: String = "";
-    private var to: String = "";
-    private var signal: String = "";
-    private var method: String = "";
+    private var from: String = ""
+    private var to: String = ""
+    private var signal: String = ""
+    private var method: String = ""
 
     constructor(parent: StubElement<*>?, from: String, to: String, signal: String, method: String) : super(parent, TscnConnectionHeaderElementType) {
-        this.from = from;
-        this.to = to;
-        this.signal = signal;
-        this.method = method;
+        this.from = from
+        this.to = to
+        this.signal = signal
+        this.method = method
     }
 
     override fun getFrom(): String {
-        return from;
+        return from
     }
 
     override fun getTo(): String {
-        return to;
+        return to
     }
 
     override fun getMethod(): String {
-        return method;
+        return method
     }
 
     override fun getSignal(): String {
-        return signal;
+        return signal
     }
 
 }

--- a/gdscript/src/main/kotlin/tscn/index/stub/TscnResourceHeaderStub.kt
+++ b/gdscript/src/main/kotlin/tscn/index/stub/TscnResourceHeaderStub.kt
@@ -5,7 +5,7 @@ import tscn.psi.TscnResourceHeader
 
 interface TscnResourceHeaderStub : StubElement<TscnResourceHeader> {
 
-    fun getId(): String;
-    fun getPath(): String;
+    fun getId(): String
+    fun getPath(): String
 
 }

--- a/gdscript/src/main/kotlin/tscn/psi/TscnElementType.kt
+++ b/gdscript/src/main/kotlin/tscn/psi/TscnElementType.kt
@@ -5,6 +5,6 @@ import tscn.TscnLanguage
 
 class TscnElementType : IElementType {
 
-    constructor(debugName: String) : super(debugName, TscnLanguage);
+    constructor(debugName: String) : super(debugName, TscnLanguage)
 
 }

--- a/gdscript/src/main/kotlin/tscn/psi/TscnFile.kt
+++ b/gdscript/src/main/kotlin/tscn/psi/TscnFile.kt
@@ -10,7 +10,7 @@ class TscnFile : PsiFileBase {
 
     constructor(viewProvider: FileViewProvider) : super(viewProvider, TscnLanguage)
 
-    override fun getFileType(): FileType = TscnFileType;
+    override fun getFileType(): FileType = TscnFileType
 
     override fun toString(): String = "GodotScene file"
 

--- a/gdscript/src/main/kotlin/tscn/psi/TscnTokenType.kt
+++ b/gdscript/src/main/kotlin/tscn/psi/TscnTokenType.kt
@@ -5,7 +5,7 @@ import tscn.TscnLanguage
 
 class TscnTokenType : IElementType {
 
-    constructor(debugName: String) : super(debugName, TscnLanguage);
+    constructor(debugName: String) : super(debugName, TscnLanguage)
 
     override fun toString(): String = "TscnTokenType.${super.toString()}"
 

--- a/gdscript/src/main/kotlin/tscn/psi/impl/TscnConnectionHeaderElementType.kt
+++ b/gdscript/src/main/kotlin/tscn/psi/impl/TscnConnectionHeaderElementType.kt
@@ -20,10 +20,10 @@ object TscnConnectionHeaderElementType : IStubElementType<TscnConnectionHeaderSt
     override fun getExternalId(): String = "tscn.connection"
 
     override fun serialize(stub: TscnConnectionHeaderStub, dataStream: StubOutputStream) {
-        dataStream.writeName(stub.getFrom());
-        dataStream.writeName(stub.getTo());
-        dataStream.writeName(stub.getSignal());
-        dataStream.writeName(stub.getMethod());
+        dataStream.writeName(stub.getFrom())
+        dataStream.writeName(stub.getTo())
+        dataStream.writeName(stub.getSignal())
+        dataStream.writeName(stub.getMethod())
     }
 
     override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?): TscnConnectionHeaderStub =
@@ -36,13 +36,13 @@ object TscnConnectionHeaderElementType : IStubElementType<TscnConnectionHeaderSt
         )
 
     override fun indexStub(stub: TscnConnectionHeaderStub, sink: IndexSink) {
-        sink.occurrence(TscnIndices.CONNECTION_INDEX, stub.getMethod());
+        sink.occurrence(TscnIndices.CONNECTION_INDEX, stub.getMethod())
     }
 
     override fun createPsi(stub: TscnConnectionHeaderStub): TscnConnectionHeader =
-        TscnConnectionHeaderImpl(stub, stub.stubType);
+        TscnConnectionHeaderImpl(stub, stub.stubType)
 
     override fun createStub(psi: TscnConnectionHeader, parentStub: StubElement<out PsiElement>?): TscnConnectionHeaderStub =
-        TscnConnectionHeaderStubImpl(parentStub, psi.from, psi.to, psi.signal, psi.method);
+        TscnConnectionHeaderStubImpl(parentStub, psi.from, psi.to, psi.signal, psi.method)
 
 }

--- a/gdscript/src/main/kotlin/tscn/psi/impl/TscnNodeHeaderElementType.kt
+++ b/gdscript/src/main/kotlin/tscn/psi/impl/TscnNodeHeaderElementType.kt
@@ -45,11 +45,11 @@ object TscnNodeHeaderElementType :
         )
 
     override fun indexStub(stub: TscnNodeHeaderStub, sink: IndexSink) {
-        sink.occurrence(TscnIndices.NODE_INDEX, stub.getNodePath());
+        sink.occurrence(TscnIndices.NODE_INDEX, stub.getNodePath())
     }
 
     override fun createPsi(stub: TscnNodeHeaderStub): TscnNodeHeader =
-        TscnNodeHeaderImpl(stub, stub.stubType);
+        TscnNodeHeaderImpl(stub, stub.stubType)
 
     override fun createStub(psi: TscnNodeHeader, parentStub: StubElement<out PsiElement>?): TscnNodeHeaderStub =
         TscnNodeHeaderStubImpl(
@@ -64,6 +64,6 @@ object TscnNodeHeaderElementType :
             psi.instanceResource,
             psi.groups,
             psi.index,
-        );
+        )
 
 }

--- a/gdscript/src/main/kotlin/tscn/psi/impl/TscnParagraphElementType.kt
+++ b/gdscript/src/main/kotlin/tscn/psi/impl/TscnParagraphElementType.kt
@@ -22,13 +22,13 @@ object TscnParagraphElementType :
         TscnParagraphStubImpl(parentStub)
 
     override fun indexStub(stub: TscnParagraphStub, sink: IndexSink) {
-        sink.occurrence(TscnIndices.PARAGRAPH_INDEX, "paragraph");
+        sink.occurrence(TscnIndices.PARAGRAPH_INDEX, "paragraph")
     }
 
     override fun createPsi(stub: TscnParagraphStub): TscnParagraph =
-        TscnParagraphImpl(stub, stub.stubType);
+        TscnParagraphImpl(stub, stub.stubType)
 
     override fun createStub(psi: TscnParagraph, parentStub: StubElement<out PsiElement>?): TscnParagraphStub =
-        TscnParagraphStubImpl(parentStub);
+        TscnParagraphStubImpl(parentStub)
 
 }

--- a/gdscript/src/main/kotlin/tscn/psi/impl/TscnResourceHeaderElementType.kt
+++ b/gdscript/src/main/kotlin/tscn/psi/impl/TscnResourceHeaderElementType.kt
@@ -23,8 +23,8 @@ object TscnResourceHeaderElementType : IStubElementType<TscnResourceHeaderStub, 
     override fun getExternalId(): String = "tscn.extResource"
 
     override fun serialize(stub: TscnResourceHeaderStub, dataStream: StubOutputStream) {
-        dataStream.writeName(stub.getId());
-        dataStream.writeName(stub.getPath());
+        dataStream.writeName(stub.getId())
+        dataStream.writeName(stub.getPath())
     }
 
     override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?): TscnResourceHeaderStub =
@@ -35,17 +35,17 @@ object TscnResourceHeaderElementType : IStubElementType<TscnResourceHeaderStub, 
         )
 
     override fun indexStub(stub: TscnResourceHeaderStub, sink: IndexSink) {
-        sink.occurrence(TscnIndices.RESOURCE_INDEX, stub.getPath());
+        sink.occurrence(TscnIndices.RESOURCE_INDEX, stub.getPath())
     }
 
     override fun createPsi(stub: TscnResourceHeaderStub): TscnResourceHeader =
-        TscnResourceHeaderImpl(stub, stub.stubType);
+        TscnResourceHeaderImpl(stub, stub.stubType)
 
     override fun createStub(psi: TscnResourceHeader, parentStub: StubElement<out PsiElement>?): TscnResourceHeaderStub =
-        TscnResourceHeaderStubImpl(parentStub, psi.id, psi.path);
+        TscnResourceHeaderStubImpl(parentStub, psi.id, psi.path)
 
     override fun shouldCreateStub(node: ASTNode): Boolean {
-        val element = node.psi as TscnResourceHeader;
+        val element = node.psi as TscnResourceHeader
 
         return TO_INDEX.contains(element.type)
     }

--- a/gdscript/src/main/kotlin/tscn/psi/search/TscnMethodSearcher.kt
+++ b/gdscript/src/main/kotlin/tscn/psi/search/TscnMethodSearcher.kt
@@ -15,7 +15,7 @@ class TscnMethodSearcher(val method: GdMethodIdNmi, project: Project) : Abstract
             return true
         }
         // or search for matches in an animation track
-        return listAnimationReference("\"method\": &\"${method.name}\"", true, "method").any();
+        return listAnimationReference("\"method\": &\"${method.name}\"", true, "method").any()
     }
 
     fun listMethodReferences() : List<UsageInfo> {

--- a/gdscript/src/main/kotlin/tscn/psi/search/processor/TscnConnectionHeaderCollectingProcessor.kt
+++ b/gdscript/src/main/kotlin/tscn/psi/search/processor/TscnConnectionHeaderCollectingProcessor.kt
@@ -13,7 +13,7 @@ class TscnConnectionHeaderCollectingProcessor : TextOccurenceProcessor {
             result.add(element)
         }
         // always continue
-        return true;
+        return true
     }
 
 }

--- a/gdscript/src/main/kotlin/tscn/psi/search/processor/TscnParagraphCollectingProcessor.kt
+++ b/gdscript/src/main/kotlin/tscn/psi/search/processor/TscnParagraphCollectingProcessor.kt
@@ -20,7 +20,7 @@ class TscnParagraphCollectingProcessor(val type: String) : TextOccurenceProcesso
             }
         }
         // always continue
-        return true;
+        return true
     }
 
 }

--- a/gdscript/src/main/kotlin/tscn/psi/utils/TscnConnectionUtil.kt
+++ b/gdscript/src/main/kotlin/tscn/psi/utils/TscnConnectionUtil.kt
@@ -9,31 +9,31 @@ import tscn.psi.TscnConnectionHeader
 object TscnConnectionUtil {
 
     fun getFrom(element: TscnConnectionHeader): String {
-        val stub = element.stub;
-        if (stub != null) return stub.getFrom();
+        val stub = element.stub
+        if (stub != null) return stub.getFrom()
 
-        return TscnHeaderUtils.getValue(element.headerValueList, TscnHeaderUtils.HL_FROM);
+        return TscnHeaderUtils.getValue(element.headerValueList, TscnHeaderUtils.HL_FROM)
     }
 
     fun getTo(element: TscnConnectionHeader): String {
-        val stub = element.stub;
-        if (stub != null) return stub.getTo();
+        val stub = element.stub
+        if (stub != null) return stub.getTo()
 
-        return TscnHeaderUtils.getValue(element.headerValueList, TscnHeaderUtils.HL_TO);
+        return TscnHeaderUtils.getValue(element.headerValueList, TscnHeaderUtils.HL_TO)
     }
 
     fun getSignal(element: TscnConnectionHeader): String {
-        val stub = element.stub;
-        if (stub != null) return stub.getSignal();
+        val stub = element.stub
+        if (stub != null) return stub.getSignal()
 
-        return TscnHeaderUtils.getValue(element.headerValueList, TscnHeaderUtils.HL_SIGNAL);
+        return TscnHeaderUtils.getValue(element.headerValueList, TscnHeaderUtils.HL_SIGNAL)
     }
 
     fun getMethod(element: TscnConnectionHeader): String {
-        val stub = element.stub;
-        if (stub != null) return stub.getMethod();
+        val stub = element.stub
+        if (stub != null) return stub.getMethod()
 
-        return TscnHeaderUtils.getValue(element.headerValueList, TscnHeaderUtils.HL_METHOD);
+        return TscnHeaderUtils.getValue(element.headerValueList, TscnHeaderUtils.HL_METHOD)
     }
 
 }

--- a/gdscript/src/main/kotlin/tscn/psi/utils/TscnNodeUtil.kt
+++ b/gdscript/src/main/kotlin/tscn/psi/utils/TscnNodeUtil.kt
@@ -36,10 +36,10 @@ object TscnNodeUtil {
     }
 
     fun getName(element: TscnNodeHeader): String {
-        val stub = element.stub;
-        if (stub != null) return stub.getName();
+        val stub = element.stub
+        if (stub != null) return stub.getName()
 
-        return TscnHeaderUtils.getValue(element.headerValueList, TscnHeaderUtils.HL_NAME);
+        return TscnHeaderUtils.getValue(element.headerValueList, TscnHeaderUtils.HL_NAME)
     }
 
     fun getType(element: TscnNodeHeader): String {
@@ -50,10 +50,10 @@ object TscnNodeUtil {
     }
 
     fun getParentPath(element: TscnNodeHeader): String {
-        val stub = element.stub;
-        if (stub != null) return stub.getParentPath();
+        val stub = element.stub
+        if (stub != null) return stub.getParentPath()
 
-        return TscnHeaderUtils.getValue(element.headerValueList, TscnHeaderUtils.HL_PARENT);
+        return TscnHeaderUtils.getValue(element.headerValueList, TscnHeaderUtils.HL_PARENT)
     }
 
     fun getGroups(element: TscnNodeHeader): Array<String> {
@@ -68,7 +68,7 @@ object TscnNodeUtil {
     }
 
     fun getInstanceResource(element: TscnNodeHeader): String {
-        val stub = element.stub;
+        val stub = element.stub
         if (stub != null) return stub.getScriptResource()
 
         // ExtResource("1"), ExtResource( 1 )
@@ -109,7 +109,7 @@ object TscnNodeUtil {
     }
 
     fun getScriptResource(element: TscnNodeHeader): String {
-        val stub = element.stub;
+        val stub = element.stub
         if (stub != null) return stub.getScriptResource()
 
         // ExtResource("2_s5kgd"), ExtResource( 1 )
@@ -145,10 +145,10 @@ object TscnNodeUtil {
     }
 
     fun hasScript(element: TscnNodeHeader): Boolean {
-        val stub = element.stub;
-        if (stub != null) return stub.hasScript();
+        val stub = element.stub
+        if (stub != null) return stub.hasScript()
 
-        return getScriptResource(element).isNotBlank();
+        return getScriptResource(element).isNotBlank()
     }
 
     fun listAllGroups(element: PsiElement): Array<String> {

--- a/gdscript/src/main/kotlin/tscn/psi/utils/TscnResourceUtil.kt
+++ b/gdscript/src/main/kotlin/tscn/psi/utils/TscnResourceUtil.kt
@@ -13,21 +13,21 @@ import tscn.psi.TscnResourceHeader
 object TscnResourceUtil {
 
     fun getId(element: TscnResourceHeader): String {
-        val stub = element.stub;
-        if (stub != null) return stub.getId();
+        val stub = element.stub
+        if (stub != null) return stub.getId()
 
-        return TscnHeaderUtils.getValue(element.headerValueList, TscnHeaderUtils.HL_ID);
+        return TscnHeaderUtils.getValue(element.headerValueList, TscnHeaderUtils.HL_ID)
     }
 
     fun getPath(element: TscnResourceHeader): String {
-        val stub = element.stub;
-        if (stub != null) return stub.getPath();
+        val stub = element.stub
+        if (stub != null) return stub.getPath()
 
-        return TscnHeaderUtils.getValue(element.headerValueList, TscnHeaderUtils.HL_PATH);
+        return TscnHeaderUtils.getValue(element.headerValueList, TscnHeaderUtils.HL_PATH)
     }
 
     fun getType(element: TscnResourceHeader): String {
-        return TscnHeaderUtils.getValue(element.headerValueList, TscnHeaderUtils.HL_TYPE);
+        return TscnHeaderUtils.getValue(element.headerValueList, TscnHeaderUtils.HL_TYPE)
     }
 
     @Deprecated("list list below - script might be in multiple .tscn")


### PR DESCRIPTION
Title: remove redundant semicolons

Summary
It's all in the title.
Because any attempts to work on the plugin within the default jetbrains ecosystem raises these problems in the interface, unnecessarily creating noise and adding friction to the development process.
There are no user facing ramifications, and no actual changes.
