### PR TITLE
Allow VFS root access in rename tests

### DIFF
--- a/gdscript/src/test/kotlin/com/jetbrains/godot/tscn/refactoring/rename/ResourceFieldRenamingTest.kt
+++ b/gdscript/src/test/kotlin/com/jetbrains/godot/tscn/refactoring/rename/ResourceFieldRenamingTest.kt
@@ -10,6 +10,13 @@ class ResourceFieldRenamingTest : BasePlatformTestCase() {
         return getBaseTestDataPath().resolve("testData/tscn/refactoring/rename/resourceFieldRenaming").pathString
     }
 
+    override fun setUp() {
+        super.setUp()
+        // Allow reading expected .after files from the test data directory
+        val path = getTestDataPath()
+        com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess.allowRootAccess(testRootDisposable, path)
+    }
+
     fun testRename() {
         myFixture.configureByFiles("simple_resource.gd", "simple_resource.tres")
         myFixture.renameElementAtCaret("valueRenamed")

--- a/gdscript/src/test/kotlin/com/jetbrains/godot/tscn/refactoring/rename/ScriptClassRenamingTest.kt
+++ b/gdscript/src/test/kotlin/com/jetbrains/godot/tscn/refactoring/rename/ScriptClassRenamingTest.kt
@@ -9,6 +9,13 @@ class ScriptClassRenamingTest : BasePlatformTestCase() {
         return getBaseTestDataPath().resolve("testData/tscn/refactoring/rename/scriptClassRenaming").pathString
     }
 
+    override fun setUp() {
+        super.setUp()
+        // Allow reading expected .after files from the test data directory
+        val path = getTestDataPath()
+        com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess.allowRootAccess(testRootDisposable, path)
+    }
+
     fun testRename() {
         myFixture.configureByFiles("simple_resource.gd", "simple_resource.tres")
         myFixture.renameElementAtCaret("SimpleResourceRenamed")


### PR DESCRIPTION
Add setUp in ResourceFieldRenamingTest and ScriptClassRenamingTest to allowRootAccess to the test data path. Without VFS root access, the tests can’t read expected .after files and may fail on some environments; this makes the rename tests reliable.

I dont know if this is the appropriate fix for this, I was guided by jetbrains AI tools.
Without the changes, these tests always fail for me.