### PR TITLE
Error when quitting Godot Editor with rider-plugin installed

### DIFF
--- a/godot-editor-plugin/addons/rider-plugin/cpp/src/rider_locator_gd.cpp
+++ b/godot-editor-plugin/addons/rider-plugin/cpp/src/rider_locator_gd.cpp
@@ -4,7 +4,6 @@
 #include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/core/class_db.hpp>
 #include <godot_cpp/variant/dictionary.hpp>
-#include <godot_cpp/variant/utility_functions.hpp>
 
 using namespace godot;
 

--- a/godot-editor-plugin/addons/rider-plugin/cpp/src/rider_locator_gd.h
+++ b/godot-editor-plugin/addons/rider-plugin/cpp/src/rider_locator_gd.h
@@ -2,11 +2,11 @@
 
 #pragma once
 
-#include <godot_cpp/classes/object.hpp>
+#include "godot_cpp/classes/ref_counted.hpp"
 #include <godot_cpp/variant/array.hpp>
 
-class RiderLocator : public godot::Object {
-    GDCLASS(RiderLocator, godot::Object)
+class RiderLocator : public godot::RefCounted {
+    GDCLASS(RiderLocator, godot::RefCounted)
 
 protected:
     static void _bind_methods();

--- a/godot-editor-plugin/addons/rider-plugin/cpp/src/rider_path_locator.h
+++ b/godot-editor-plugin/addons/rider-plugin/cpp/src/rider_path_locator.h
@@ -1,7 +1,3 @@
-// Simplified, GDExtension-friendly reimplementation of RiderPathLocator
-// Original code was based on Unreal Engine types. This version uses the C++
-// standard library and is safe to compile within Godot's GDExtension builds.
-
 #pragma once
 
 #include <string>

--- a/godot-editor-plugin/addons/rider-plugin/rider-plugin.gd
+++ b/godot-editor-plugin/addons/rider-plugin/rider-plugin.gd
@@ -3,7 +3,6 @@ extends EditorPlugin
 
 var editor_settings: EditorSettings
 var checkbutton: CheckButton
-var rider_button: Button
 var _preset_applier: PresetApplier
 var _settings_service: EditorSettingsService
 var _locator_service: RiderLocatorService
@@ -58,7 +57,6 @@ func _on_checkbutton_pressed() -> void:
 	_preset_applier.apply_preset(editor_settings, is_active)
 
 func _exit_tree() -> void:
-	remove_control_from_container(EditorPlugin.CONTAINER_TOOLBAR, checkbutton)
-	remove_control_from_container(EditorPlugin.CONTAINER_TOOLBAR, rider_button)
-	checkbutton.free()
-	rider_button.free()
+	if checkbutton != null:
+		remove_control_from_container(EditorPlugin.CONTAINER_TOOLBAR, checkbutton)
+		checkbutton.queue_free()

--- a/godot-editor-plugin/addons/rider-plugin/scripts/locator/rider_locator_service.gd
+++ b/godot-editor-plugin/addons/rider-plugin/scripts/locator/rider_locator_service.gd
@@ -1,4 +1,5 @@
 @tool
+extends RefCounted
 class_name RiderLocatorService
 
 func get_installations() -> Array:

--- a/godot-editor-plugin/addons/rider-plugin/scripts/presets/preset_applier.gd
+++ b/godot-editor-plugin/addons/rider-plugin/scripts/presets/preset_applier.gd
@@ -1,6 +1,5 @@
 @tool
-extends Object
-
+extends RefCounted
 class_name PresetApplier
 
 var presets_path: String

--- a/godot-editor-plugin/addons/rider-plugin/scripts/settings/editor_settings_service.gd
+++ b/godot-editor-plugin/addons/rider-plugin/scripts/settings/editor_settings_service.gd
@@ -1,6 +1,5 @@
 @tool
-extends Object
-
+extends RefCounted
 class_name EditorSettingsService
 
 func set_external_editor_path(editor_settings: EditorSettings, path: String) -> void:


### PR DESCRIPTION
Changes:
1. rider-plugin.gd — Safe cleanup in _exit_tree
Added a null check before freeing checkbutton

2. GDScript classes → extends RefCounted instead of extends Object
Three script classes were changed from Object (manual memory management) to RefCounted

3. C++ RiderLocator → inherits RefCounted instead of Object
