### PR TITLE
Add Godot headless editor smoke test to editor-plugin-ci.yml

### DIFF
--- a/.github/workflows/editor-plugin-ci.yml
+++ b/.github/workflows/editor-plugin-ci.yml
@@ -7,6 +7,16 @@ on:
   pull_request:
   merge_group:
 
+env:
+  
+  # Used to select the version of Godot to run the tests with.
+  GODOT_TEST_VERSION: 4.6.1-stable
+  # Use UTF-8 on Linux.
+  LANG: en_US.UTF-8
+  LC_ALL: en_US.UTF-8
+  # Use UTF-8 on Windows.
+  PYTHONIOENCODING: utf8
+
 defaults:
   run:
     working-directory: godot-editor-plugin/addons/rider-plugin/cpp
@@ -18,13 +28,13 @@ jobs:
       matrix:
         # Test a few selected combinations of parameters ("test case matrix").
         include:
-          - target: { platform: linux, arch: x86_64, os: ubuntu-22.04 }
+          - target: { platform: linux, arch: x86_64, os: ubuntu-22.04, run-tests: true }
             target-type: editor
             float-precision: single
-          - target: { platform: windows, arch: x86_64, os: windows-latest }
+          - target: { platform: windows, arch: x86_64, os: windows-latest, run-tests: false }
             target-type: editor
             float-precision: single
-          - target: { platform: macos, arch: universal, os: macos-latest }
+          - target: { platform: macos, arch: universal, os: macos-latest, run-tests: false }
             target-type: editor
             float-precision: single
 
@@ -62,3 +72,18 @@ jobs:
         with:
           scons-cache: ${{ github.workspace }}/.scons-cache/
           cache-name: ${{ matrix.target.platform }}_${{ matrix.target.arch }}_${{ matrix.float-precision }}_${{ matrix.target-type }}
+
+      - name: Download requested Godot version for testing
+        if: matrix.target.run-tests
+        run: |
+          wget "https://github.com/godotengine/godot/releases/download/${GODOT_TEST_VERSION}/Godot_v${GODOT_TEST_VERSION}_linux.x86_64.zip" -O Godot.zip
+          unzip -a Godot.zip
+          chmod +x "Godot_v${GODOT_TEST_VERSION}_linux.x86_64"
+          echo "GODOT=$(pwd)/Godot_v${GODOT_TEST_VERSION}_linux.x86_64" >> $GITHUB_ENV
+
+      - name: Run tests
+        if: matrix.target.run-tests
+        run: |
+          $GODOT --headless --version
+          cd ../../../
+          ./run-tests.sh

--- a/godot-editor-plugin/addons/rider-plugin/rider-plugin.gd
+++ b/godot-editor-plugin/addons/rider-plugin/rider-plugin.gd
@@ -60,3 +60,7 @@ func _exit_tree() -> void:
 	if checkbutton != null:
 		remove_control_from_container(EditorPlugin.CONTAINER_TOOLBAR, checkbutton)
 		checkbutton.queue_free()
+		
+	var args = OS.get_cmdline_args()
+	if "--rider-addon-tests" in args:
+		print("==== rider-addon-tests finished ====")

--- a/godot-editor-plugin/run-tests.sh
+++ b/godot-editor-plugin/run-tests.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+GODOT=${GODOT:-godot}
+
+END_STRING="==== rider-addon-tests finished ===="
+FAILURE_STRING="******** FAILED ********"
+
+OUTPUT=$($GODOT --editor --headless --rider-addon-tests --quit)
+ERRCODE=$?
+
+echo "$OUTPUT"
+echo
+
+if ! echo "$OUTPUT" | grep -e "$END_STRING" >/dev/null; then
+    echo "ERROR: Tests failed to complete"
+    exit 1
+fi
+
+if echo "$OUTPUT" | grep -e "$FAILURE_STRING" >/dev/null; then
+    exit 1
+fi
+
+# Success!
+exit 0


### PR DESCRIPTION
With each build result run Godot. 
./Godot_v4.6.1-stable_mono_linux.x86_64 --editor --path "full path to godot-editor-plugin folder" --headless 
check that is didn't crash and there were no error output.