### PR TITLE
fix macOS universal build by storing CMAKE_OSX_ARCHITECTURES in cache…

### DIFF
--- a/godot-editor-addon/addons/rider-plugin/cpp/CMakeLists.txt
+++ b/godot-editor-addon/addons/rider-plugin/cpp/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 # Set universal architecture for macOS builds (matches SCons default behavior)
 if(APPLE AND NOT CMAKE_OSX_ARCHITECTURES)
-    set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64")
+    set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "Build architectures for macOS" FORCE)
 endif()
 
 set(LIBNAME "rider-gdextension") # "The name of the library"


### PR DESCRIPTION
… so godot-cpp subproject picks it up

