### PR TITLE
add a default preset for cmake, ensuring to use Ninja. On Windows usi…

### DIFF
--- a/godot-editor-addon/CMakePresets.json
+++ b/godot-editor-addon/CMakePresets.json
@@ -1,0 +1,13 @@
+{
+    "version": 3,
+    "configurePresets": [
+        {
+            "name": "ninja-debug",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/ninja-debug",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
…ng default generator greatly slows down build process.

Update:
Turned out to be Rider problem 
https://youtrack.jetbrains.com/issue/RIDER-138322/Rider-Default-CMake-profile-uses-NMake-makefiles

If the issue would be resolved, would the preset still be needed?