### PR TITLE
fix RIDER-139267 Fix indents action should remove space, which can't …

### DIFF
--- a/gdscript/src/main/kotlin/gdscript/inspection/fixes/GdFixIndentsQuickFix.kt
+++ b/gdscript/src/main/kotlin/gdscript/inspection/fixes/GdFixIndentsQuickFix.kt
@@ -6,13 +6,16 @@ import com.intellij.modcommand.ModCommand
 import com.intellij.modcommand.ModCommandQuickFix
 import com.intellij.modcommand.ModPsiUpdater
 import com.intellij.openapi.editor.ConvertIndentsUtil
+import com.intellij.openapi.editor.Document
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiFile
+import com.intellij.util.DocumentUtil
 import gdscript.GdScriptBundle
 
 /**
  * Quick fix: Convert leading indentation on each line to match Code Style (tabs vs spaces).
- * Delegates to platform ConvertIndentsUtil for consistent behavior.
+ * For spaces->tabs, sub-tab remainder spaces are dropped.
  */
 class GdFixIndentsQuickFix : ModCommandQuickFix() {
     override fun getFamilyName(): String = getName()
@@ -26,11 +29,28 @@ class GdFixIndentsQuickFix : ModCommandQuickFix() {
         return ModCommand.psiUpdate(descriptor.psiElement.containingFile) { mutableFile: PsiFile, _: ModPsiUpdater ->
             val indentOptions = CodeStyle.getSettings(mutableFile).getIndentOptionsByFile(mutableFile.containingFile)
             val range = mutableFile.containingFile.textRange
+            val document = mutableFile.fileDocument
             if (indentOptions.USE_TAB_CHARACTER) {
-                ConvertIndentsUtil.convertIndentsToTabs(mutableFile.fileDocument, indentOptions.TAB_SIZE, range)
+                ConvertIndentsUtil.convertIndentsToTabs(document, indentOptions.TAB_SIZE, range)
+                stripSpacesFromIndents(document, range)
             }
             else {
                 ConvertIndentsUtil.convertIndentsToSpaces(mutableFile.fileDocument, indentOptions.TAB_SIZE, range)
+            }
+        }
+    }
+
+    private fun stripSpacesFromIndents(document: Document, textRange: TextRange) {
+        DocumentUtil.executeInBulk(document) {
+            val startLine = document.getLineNumber(textRange.startOffset)
+            val endLine = document.getLineNumber(textRange.endOffset)
+            for (line in startLine..endLine) {
+                val lineStart = document.getLineStartOffset(line)
+                val indent = DocumentUtil.getIndent(document, lineStart)
+                if (indent.contains(' ')) {
+                    val cleaned = indent.filter { it != ' ' }.toString()
+                    document.replaceString(lineStart, lineStart + indent.length, cleaned)
+                }
             }
         }
     }


### PR DESCRIPTION
…become tab

(cherry picked from commit 2131b6d67956e1d5f7f3c724381b6b413a3b24d9)

IJ-MR-205673

GitOrigin-RevId: 13d6039242bbfeb9d16b0a842aa7d72e0791792f

Title: <short summary>

Summary
- What does this change do? Why?
- Any user-facing behavior changes? Screenshots where helpful.

Checklist for new contributions
- [ ] The fix or feature implementation is included in this PR
- [ ] Tests are added/updated as per documentation/contribution/tests.md
  - [ ] I ran: ./gradlew test and verified they pass locally
- [ ] Optional: A YouTrack issue is linked to keep QA and release notes in the loop (https://youtrack.jetbrains.com/issues)
  - Example: RIDER-12345
  - Note: If the commit that contains the fix starts with "fix RIDER-12345 any further text", automation will mark it fixed and set the proper "fixed in build" when the change is synced to the main Rider repository
