### PR TITLE
fix RIDER-140286 GDScript LSP/DAP: multiple Godot editors conflict over one LSP/DAP port

### DIFF
--- a/community/src/main/kotlin/com/jetbrains/rider/godot/community/GdProjectGodotService.kt
+++ b/community/src/main/kotlin/com/jetbrains/rider/godot/community/GdProjectGodotService.kt
@@ -1,4 +1,4 @@
-package gdscript.library
+package com.jetbrains.rider.godot.community
 
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
@@ -10,7 +10,6 @@ import com.intellij.openapi.vfs.AsyncFileListener
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.jetbrains.rd.util.lifetime.SequentialLifetimes
 import com.jetbrains.rider.godot.community.utils.GodotCommunityUtil
-import common.util.GdScriptProjectLifetimeService
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -21,7 +20,7 @@ import kotlin.io.path.pathString
 import kotlin.io.path.readText
 
 @Service(Service.Level.PROJECT)
-class GdProjectGodotService(@Suppress("unused") project: Project) {
+class GdProjectGodotService(project: Project) {
 
     data class GodotProjectInfo(val version: String) {
         /** Parsed version; `null` for unparseable values like "Master" */

--- a/community/src/main/kotlin/com/jetbrains/rider/godot/community/GdScriptProjectLifetimeService.kt
+++ b/community/src/main/kotlin/com/jetbrains/rider/godot/community/GdScriptProjectLifetimeService.kt
@@ -1,4 +1,4 @@
-package common.util
+package com.jetbrains.rider.godot.community
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
@@ -23,6 +23,5 @@ class GdScriptProjectLifetimeService(val scope: CoroutineScope): LifetimedServic
         fun getInstance(project: Project): GdScriptProjectLifetimeService = project.service()
         fun getLifetime(project: Project): Lifetime = getInstance(project).serviceLifetime
         fun getScope(project: Project): CoroutineScope = project.service<GdScriptProjectLifetimeService>().scope
-
     }
 }

--- a/community/src/main/kotlin/com/jetbrains/rider/godot/community/actions/StartGodotEditorAction.kt
+++ b/community/src/main/kotlin/com/jetbrains/rider/godot/community/actions/StartGodotEditorAction.kt
@@ -1,11 +1,15 @@
 package com.jetbrains.rider.godot.community.actions
 
 import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.configurations.ParametersList
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Version
+import com.intellij.util.NetworkUtils
+import com.jetbrains.rider.godot.community.GdProjectGodotService
 import com.jetbrains.rider.godot.community.utils.GodotCommunityUtil
 
 object StartGodotEditorAction : DumbAwareAction() {
@@ -35,6 +39,9 @@ object StartGodotEditorAction : DumbAwareAction() {
     fun startEditor(project: Project) {
         val launchConfig = GodotCommunityUtil.getEditorLaunchConfig(project) ?: return
 
+        val parsedVersion = GdProjectGodotService.getInstance(project).projectInfoFlow.value?.parsedVersion
+        val arguments = withDefaultServerPorts(launchConfig.arguments, parsedVersion)
+
         val runCommandLine = GeneralCommandLine(launchConfig.executablePath.toString())
             .withEnvironment(launchConfig.environmentVariables)
             .withParentEnvironmentType(
@@ -45,7 +52,7 @@ object StartGodotEditorAction : DumbAwareAction() {
                 }
             )
             .withWorkingDirectory(launchConfig.workingDirectory)
-            .withParameters(launchConfig.arguments)
+            .withParameters(arguments)
 
         logger.info("Starting Godot editor: ${runCommandLine.commandLineString}")
 
@@ -54,6 +61,38 @@ object StartGodotEditorAction : DumbAwareAction() {
             .redirectError(ProcessBuilder.Redirect.DISCARD)
             .redirectOutput(ProcessBuilder.Redirect.DISCARD)
             .start()
+    }
+
+    /**
+     * Ensures `--lsp-port` and `--dap-port` are present so a running editor can be discovered later
+     * (see `RunningGodotEditorDiscovery`). User-supplied values are preserved.
+     */
+    internal fun withDefaultServerPorts(arguments: List<String>, parsedVersion: Version?): List<String> {
+        val params = ParametersList().apply { addAll(arguments) }
+        val hasLspPort = params.hasParameter("--lsp-port")
+        val hasDapPort = params.hasParameter("--dap-port")
+
+        val supportsLspPort = parsedVersion == null || !parsedVersion.lessThan(4, 2)
+        val supportsDapPort = parsedVersion == null || !parsedVersion.lessThan(4, 3)
+
+        val needLsp = !hasLspPort && supportsLspPort
+        val needDap = !hasDapPort && supportsDapPort
+        if (!needLsp && !needDap) return arguments
+
+        // Start the LSP and DAP searches from different base ports so that, when both are needed,
+        // findFreePort doesn't hand out the same port twice before either is bound. The DAP search
+        // also excludes the LSP port as a second safeguard.
+        val result = arguments.toMutableList()
+        var lspPort: Int? = null
+        if (needLsp) {
+            lspPort = NetworkUtils.findFreePort(500050)
+            result += listOf("--lsp-port", lspPort.toString())
+        }
+        if (needDap) {
+            val dapPort = NetworkUtils.findFreePort(500060, setOfNotNull(lspPort))
+            result += listOf("--dap-port", dapPort.toString())
+        }
+        return result
     }
 
     private val logger = Logger.getInstance(StartGodotEditorAction::class.java)

--- a/gdscript/src/main/kotlin/GdScriptToolWindowManagerProjectActivity.kt
+++ b/gdscript/src/main/kotlin/GdScriptToolWindowManagerProjectActivity.kt
@@ -1,8 +1,8 @@
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
 import com.jetbrains.rd.util.threading.coroutines.launch
+import com.jetbrains.rider.godot.community.GdScriptProjectLifetimeService
 import com.jetbrains.rider.godot.community.utils.GodotCommunityUtil
-import common.util.GdScriptProjectLifetimeService
 import tscn.toolWindow.TscnScenePreviewWindowFactory
 
 class GdScriptToolWindowManagerProjectActivity : ProjectActivity {

--- a/gdscript/src/main/kotlin/gdscript/dap/GdScriptDebugAdapterSupportProvider.kt
+++ b/gdscript/src/main/kotlin/gdscript/dap/GdScriptDebugAdapterSupportProvider.kt
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 package gdscript.dap
 
 import com.intellij.execution.ExecutionResult
@@ -13,16 +15,18 @@ import com.intellij.platform.dap.DebugAdapterId
 import com.intellij.platform.dap.DebugAdapterSupportProvider
 import com.intellij.platform.dap.connection.DebugAdapterHandle
 import com.intellij.platform.dap.connection.DebugAdapterSocketConnection
+import com.jetbrains.rider.godot.community.utils.GodotCommunityUtil
 import gdscript.GdScriptBundle
 import gdscript.dap.breakpoints.GdScriptExceptionBreakpointType
 import gdscript.dap.breakpoints.GdScriptLineBreakpointType
 import gdscript.lsp.GodotLspRunningStatusProvider
+import gdscript.lsp.RunningGodotEditorDiscovery
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 object GdScriptDebugAdapter : DebugAdapterId("gdscript", GdScriptBundle.message("gdscript.debug.adapter.presentable.name"))
 
-private class GdScriptDebugAdapterSupportProvider : DebugAdapterSupportProvider<GdScriptDebugAdapter> {
+internal class GdScriptDebugAdapterSupportProvider : DebugAdapterSupportProvider<GdScriptDebugAdapter> {
     override val adapterId = GdScriptDebugAdapter
     override fun createDebugAdapterDescriptor(project: Project): DebugAdapterDescriptor<GdScriptDebugAdapter> =
         object : DebugAdapterDescriptor<GdScriptDebugAdapter>() {
@@ -34,21 +38,23 @@ private class GdScriptDebugAdapterSupportProvider : DebugAdapterSupportProvider<
                 sessionId: String,
             ): DebugAdapterHandle {
                 val config = environment.runnerAndConfigurationSettings!!.configuration as GdScriptRunConfiguration
+                // If a Godot editor for this project is already running with `--dap-port`, prefer it
+                val port = discoverRunningDapPort(project) ?: config.structured.debugServerPort
                 try {
                     return DebugAdapterSocketConnection(
                         host = GdScriptRunFactory.DEFAULT_ADDRESS,
-                        port = config.structured.debugServerPort, connectionAttempts = 1)
+                        port = port, connectionAttempts = 1)
                 }
-                catch (e: Exception) {
+                catch (_: Exception) {
                     // handling of cases, if Editor is not running or the port is not matching
                     // let user fix the port or start the editor and then, we will try to connect again
                     withContext(Dispatchers.EDT) {
                         EditConfigurationsDialog(project).show()
                     }
-
+                    
                     return DebugAdapterSocketConnection(
                         host = GdScriptRunFactory.DEFAULT_ADDRESS,
-                        port = config.structured.debugServerPort,
+                        port = port,
                         connectionAttempts = 2)
                 }
                 finally {
@@ -67,4 +73,9 @@ private class GdScriptDebugAdapterSupportProvider : DebugAdapterSupportProvider<
                 }
             }
         }
+}
+
+private suspend fun discoverRunningDapPort(project: Project): Int? {
+    val basePath = GodotCommunityUtil.getGodotProjectBasePath(project) ?: return null
+    return RunningGodotEditorDiscovery.findRunningGodotDapPort(basePath)
 }

--- a/gdscript/src/main/kotlin/gdscript/dap/GdScriptRunConfigurationGenerator.kt
+++ b/gdscript/src/main/kotlin/gdscript/dap/GdScriptRunConfigurationGenerator.kt
@@ -5,8 +5,8 @@ import com.intellij.execution.configurations.ConfigurationTypeUtil
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
+import com.jetbrains.rider.godot.community.GdScriptProjectLifetimeService
 import com.jetbrains.rider.godot.community.utils.GodotCommunityUtil
-import common.util.GdScriptProjectLifetimeService
 import kotlinx.coroutines.launch
 
 @Service(Service.Level.PROJECT)

--- a/gdscript/src/main/kotlin/gdscript/dap/GdScriptRunConfigurationSettingsEditor.kt
+++ b/gdscript/src/main/kotlin/gdscript/dap/GdScriptRunConfigurationSettingsEditor.kt
@@ -4,7 +4,7 @@ import com.intellij.execution.impl.CheckableRunConfigurationEditor
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
 import com.jetbrains.rd.util.lifetime.LifetimeDefinition
-import common.util.GdScriptProjectLifetimeService
+import com.jetbrains.rider.godot.community.GdScriptProjectLifetimeService
 import javax.swing.JPanel
 
 class GdScriptRunConfigurationSettingsEditor(project: Project) : SettingsEditor<GdScriptRunConfiguration>(),

--- a/gdscript/src/main/kotlin/gdscript/library/GdExtensionWatchService.kt
+++ b/gdscript/src/main/kotlin/gdscript/library/GdExtensionWatchService.kt
@@ -10,7 +10,6 @@ import com.intellij.openapi.util.io.toNioPathOrNull
 import com.intellij.openapi.vfs.AsyncFileListener
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
-import com.intellij.openapi.vfs.newvfs.events.VFileCopyEvent
 import com.intellij.openapi.vfs.newvfs.events.VFileCreateEvent
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent
 import com.intellij.openapi.vfs.newvfs.events.VFilePropertyChangeEvent
@@ -19,8 +18,8 @@ import com.intellij.psi.search.FilenameIndex
 import com.intellij.psi.search.ProjectScope
 import com.jetbrains.rd.util.lifetime.SequentialLifetimes
 import com.jetbrains.rd.util.lifetime.isAlive
+import com.jetbrains.rider.godot.community.GdScriptProjectLifetimeService
 import com.jetbrains.rider.godot.community.utils.GodotCommunityUtil
-import common.util.GdScriptProjectLifetimeService
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/gdscript/src/main/kotlin/gdscript/listener/ReferenceGdLibrariesProjectActivity.kt
+++ b/gdscript/src/main/kotlin/gdscript/listener/ReferenceGdLibrariesProjectActivity.kt
@@ -9,11 +9,11 @@ import com.intellij.openapi.util.registry.RegistryManager
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.platform.ide.progress.withBackgroundProgress
 import com.jetbrains.rider.godot.community.utils.GodotCommunityUtil
-import common.util.GdScriptProjectLifetimeService
+import com.jetbrains.rider.godot.community.GdScriptProjectLifetimeService
 import gdscript.GdScriptBundle
 import gdscript.library.GdExtensionWatchService
 import gdscript.library.GdLibraryManager
-import gdscript.library.GdProjectGodotService
+import com.jetbrains.rider.godot.community.GdProjectGodotService
 import gdscript.sdk.xml.XmlToGd
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview

--- a/gdscript/src/main/kotlin/gdscript/lsp/GodotLsp4jClient.kt
+++ b/gdscript/src/main/kotlin/gdscript/lsp/GodotLsp4jClient.kt
@@ -6,16 +6,22 @@ import com.intellij.platform.lsp.api.Lsp4jClient
 import com.intellij.platform.lsp.api.LspClientManager
 import com.intellij.platform.lsp.api.LspServerNotificationsHandler
 import com.jetbrains.rider.godot.community.utils.GodotCommunityUtil
+import org.eclipse.lsp4j.MessageParams
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
 import kotlin.io.path.Path
 
 /**
- * Custom Lsp4jClient implementation to catch the "gdscript_client/changeWorkspace" message.
+ * Custom Lsp4jClient implementation to:
+ *  - catch the Godot-specific `gdscript_client/changeWorkspace` notification and disconnect on
+ *    project mismatch;
+ *  - suppress the standard `window/showMessage` notification, which Godot's GDScript LSP server
+ *    emits only as a workspace-mismatch warning right next to `gdscript_client/changeWorkspace`
+ *    (see `gdscript_language_protocol.cpp`). Showing it would just duplicate our own notification.
  */
 class GodotLsp4jClient(
     handler: LspServerNotificationsHandler,
     private val project: Project
-) : Lsp4jClient(handler) {
+) : Lsp4jClient(SuppressShowMessageHandler(handler)) {
 
     private class GodotChangeWorkspaceParams(
         val path: String
@@ -34,6 +40,20 @@ class GodotLsp4jClient(
 
             GodotLspNotification.getService(project).showNonMatchingProjectWarning()
             LspClientManager.getInstance(project).stopClients(GodotLspIntegrationProvider::class.java)
+        }
+    }
+
+    /**
+     * Wraps the platform-provided [LspServerNotificationsHandler] and drops `window/showMessage`
+     * notifications, which Godot uses to deliver the same workspace-mismatch warning that we
+     * already handle via `gdscript_client/changeWorkspace`. All other notifications/requests are
+     * forwarded unchanged.
+     */
+    private class SuppressShowMessageHandler(
+        delegate: LspServerNotificationsHandler
+    ) : LspServerNotificationsHandler by delegate {
+        override fun showMessage(params: MessageParams) {
+            thisLogger().info("Suppressed window/showMessage from Godot LSP: ${params.message}")
         }
     }
 }

--- a/gdscript/src/main/kotlin/gdscript/lsp/GodotLspIntegrationProvider.kt
+++ b/gdscript/src/main/kotlin/gdscript/lsp/GodotLspIntegrationProvider.kt
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 package gdscript.lsp
 
 import GdScriptPluginIcons
@@ -27,18 +29,18 @@ import com.intellij.platform.lsp.api.customization.LspInlayHintCustomizer
 import com.intellij.platform.lsp.api.customization.LspInlayHintDisabled
 import com.intellij.platform.lsp.api.lsWidget.LspClientWidgetItem
 import com.intellij.util.NetworkUtils
-import com.intellij.util.ui.update.MergingUpdateQueue
-import com.intellij.util.ui.update.Update
+import com.intellij.util.ui.update.DebouncedUpdates
+import com.intellij.util.ui.update.UpdateQueue
+import com.jetbrains.rider.godot.community.GdProjectGodotService
 import com.jetbrains.rider.godot.community.GodotMajorVersion
 import com.jetbrains.rider.godot.community.utils.GodotCommunityUtil
 import com.jetbrains.rider.godot.community.utils.GodotFileUtil
-import common.util.GdScriptProjectLifetimeService
-import gdscript.library.GdProjectGodotService
 import gdscript.settings.GdDocProviderMode
 import gdscript.settings.GdLspConnectionMode
 import gdscript.settings.GdLspSettingsFlowService
 import gdscript.settings.GdProjectSettingsState
 import gdscript.settings.GdSettingsConfigurable
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
@@ -48,206 +50,215 @@ import org.eclipse.lsp4j.CompletionItemCapabilities
 import org.eclipse.lsp4j.Diagnostic
 import org.eclipse.lsp4j.MarkdownCapabilities
 import org.eclipse.lsp4j.TextDocumentClientCapabilities
-import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration.Companion.seconds
 
 @Service(Service.Level.PROJECT)
-class GodotLspProjectService(val project: Project) {
-    var isScheduled: AtomicBoolean = AtomicBoolean(false)
+class GodotLspProjectService(val project: Project, scope: CoroutineScope) {
 
     companion object {
         fun getInstance(project: Project): GodotLspProjectService = project.service<GodotLspProjectService>()
     }
 
-    fun queueRestart() {
-        mergingUpdateQueue.queue(mergingUpdateQueueAction)
-    }
+    private val restartQueue: UpdateQueue<Unit> =
+        DebouncedUpdates.forScope<Unit>(scope, "GodotLspRestart", 1.seconds)
+            .restartTimerOnAdd(true)
+            .runLatest { rebuildAndStart() }
 
-    private val mergingUpdateQueue: MergingUpdateQueue =
-        MergingUpdateQueue("GodotLspServerSupportProviderMergingUpdateQueue", 1000, true, null).setRestartTimerOnAdd(true)
-    private val mergingUpdateQueueAction: Update = object : Update("restartServerIfNeeded") {
-        override fun run() {
-            restartServer()
+    init {
+        val settings = GdLspSettingsFlowService.getInstance(project)
+
+        scope.launch(Dispatchers.IO) {
+            settings.lspConnectionMode.filterNotNull().collect { mode ->
+                if (mode == GdLspConnectionMode.Never) {
+                    LspClientManager.getInstance(project).stopClients(GodotLspIntegrationProvider::class.java)
+                } else {
+                    restartQueue.queue(Unit)
+                }
+            }
         }
+
+        scope.launch(Dispatchers.IO) {
+            settings.remoteHostPort.filterNotNull().collect { restartQueue.queue(Unit) }
+        }
+
+        scope.launch(Dispatchers.IO) {
+            GodotCommunityUtil.getGodotProjectBasePathFlow(project)
+                .filterNotNull().collect { restartQueue.queue(Unit) }
+        }
+
+        // Initial rebuild — debounced together with whatever the flows above emit on first collect.
+        restartQueue.queue(Unit)
     }
 
-    fun restartServer() {
-        thisLogger().info("stopAndRestartIfNeeded")
-        LspClientManager.getInstance(project).stopAndRestartClientsIfNeeded(GodotLspIntegrationProvider::class.java)
+    fun queueRestart() {
+        restartQueue.queue(Unit)
     }
+
+    private suspend fun rebuildAndStart() {
+        val settings = GdLspSettingsFlowService.getInstance(project)
+        val manager = LspClientManager.getInstance(project)
+        if (!allReady(settings, project)) {
+            manager.stopClients(GodotLspIntegrationProvider::class.java)
+            return
+        }
+
+        val basePath = GodotCommunityUtil.getGodotProjectBasePath(project)
+        val port = basePath?.let { RunningGodotEditorDiscovery.findRunningGodotLspPort(it) }
+        if (port != null) {
+            thisLogger().info("Reusing --lsp-port=$port from a running Godot editor for $basePath")
+        }
+
+        thisLogger().info("rebuildAndStart: stop + ensureClientStarted")
+        manager.stopClients(GodotLspIntegrationProvider::class.java)
+        manager.ensureClientStarted(
+            GodotLspIntegrationProvider::class.java,
+            GodotLspClientDescriptor(project, port),
+        )
+    }
+
+    private fun allReady(settings: GdLspSettingsFlowService, project: Project): Boolean = (
+        settings.lspConnectionMode.value != GdLspConnectionMode.Never
+            && (settings.lspConnectionMode.value == GdLspConnectionMode.ConnectRunningEditor || GodotCommunityUtil.getGodotExecutablePath(
+            project
+        ) != null)
+            && settings.remoteHostPort.value != null
+            && GodotCommunityUtil.getGodotProjectBasePath(project) != null
+        )
 }
 
 class GodotLspIntegrationProvider : LspIntegrationProvider {
     override fun createWidgetItem(lspClient: LspClient, currentFile: VirtualFile?): LspClientWidgetItem =
-        GodotLspClientWidgetItem(lspClient, currentFile, GdScriptPluginIcons.Icons.GodotLogo, settingsPageClass = GdSettingsConfigurable::class.java)
-
-    override fun fileOpened(project: Project, file: VirtualFile, clientStarter: LspIntegrationProvider.LspClientStarter) {
-        if (GodotFileUtil.isGdFile(file)) {
-            val settings = GdLspSettingsFlowService.getInstance(project)
-            val lspService = GodotLspProjectService.getInstance(project)
-
-            // subscribe one time to everything
-            if (lspService.isScheduled.compareAndSet(false, true)) {
-                val scope = GdScriptProjectLifetimeService.getScope(project)
-                scope.launch(Dispatchers.IO) {
-                    settings.lspConnectionMode.filterNotNull().collect { lspConnectionMode ->
-                        if (lspConnectionMode == GdLspConnectionMode.Never) {
-                            LspClientManager.getInstance(project).stopClients(GodotLspIntegrationProvider::class.java)
-                        } else
-                            scheduleStartIfNeeded(project)
-                    }
-                }
-
-                scope.launch(Dispatchers.IO) {
-                    settings.remoteHostPort.filterNotNull().collect {
-                        scheduleStartIfNeeded(project)
-                    }
-                }
-
-                scope.launch(Dispatchers.IO) {
-                    GodotCommunityUtil.isPureGdScriptProjectFlow(project).collect {
-                        scheduleStartIfNeeded(project)
-                    }
-                }
-
-                scope.launch(Dispatchers.IO) {
-                    GodotCommunityUtil.getGodotProjectBasePathFlow(project)
-                        .filterNotNull().collect {
-                            scheduleStartIfNeeded(project)
-                        }
-                }
-            }
-
-            // start, it is ok to call multiple times, but not too often
-            if (allReady(settings, project)) {
-                thisLogger().info("ensureServerStarted")
-                // this does not start a server if the `fileOpened` has already ended
-                clientStarter.ensureClientStarted(GodotLspClientDescriptor(project))
-            }
-        }
-    }
-
-    private fun allReady(discoverer: GdLspSettingsFlowService, project: Project) = (
-        discoverer.lspConnectionMode.value != GdLspConnectionMode.Never
-            && (discoverer.lspConnectionMode.value == GdLspConnectionMode.ConnectRunningEditor || GodotCommunityUtil.getGodotExecutablePath(project) != null)
-            && discoverer.remoteHostPort.value != null
-            && GodotCommunityUtil.getGodotProjectBasePath(project) != null
+        GodotLspClientWidgetItem(
+            lspClient,
+            currentFile,
+            GdScriptPluginIcons.Icons.GodotLogo,
+            settingsPageClass = GdSettingsConfigurable::class.java
         )
 
-    private fun scheduleStartIfNeeded(project: Project) {
-        val godotLspProjectService = GodotLspProjectService.getInstance(project)
-        val discoverer = GdLspSettingsFlowService.getInstance(project)
-        if (!allReady(discoverer, project)) return
-        godotLspProjectService.queueRestart()
+    override fun fileOpened(
+        project: Project,
+        file: VirtualFile,
+        clientStarter: LspIntegrationProvider.LspClientStarter
+    ) {
+        if (!GodotFileUtil.isGdFile(file)) return
+        GodotLspProjectService.getInstance(project)
+    }
+}
+
+private class GodotLspClientDescriptor(
+    project: Project,
+    private val discoveredRunningLspPort: Int?,
+) : LspClientDescriptor(
+    project,
+    "Godot",
+    GodotCommunityUtil.getGodotProjectBasePath(project)?.let { VfsUtil.findFile(it, false) }!!
+) {
+    val settings = GdLspSettingsFlowService.getInstance(project)
+    val lspConnectionMode by lazy { settings.lspConnectionMode.value }
+
+    val remoteHostPort: Int? by lazy {
+        if (useDynamicPort) NetworkUtils.findFreePort(500050) else
+            discoveredRunningLspPort ?: settings.remoteHostPort.value
     }
 
-    private class GodotLspClientDescriptor(project: Project) : LspClientDescriptor(
-        project,
-        "Godot",
-        GodotCommunityUtil.getGodotProjectBasePath(project)?.let { VfsUtil.findFile(it, false) }!!
-    ) {
-        val settings = GdLspSettingsFlowService.getInstance(project)
-        val lspConnectionMode by lazy { settings.lspConnectionMode.value }
-        val remoteHostPort by lazy { if (useDynamicPort) NetworkUtils.findFreePort(500050) else settings.remoteHostPort.value }
+    //val dapPort by lazy { NetworkUtils.findFreePort(500060, setOf()) }
+    val useDynamicPort by lazy { settings.lspConnectionMode.value == GdLspConnectionMode.StartEditorHeadless }
 
-        //val dapPort by lazy { NetworkUtils.findFreePort(500060, setOf()) }
-        val useDynamicPort by lazy { settings.lspConnectionMode.value == GdLspConnectionMode.StartEditorHeadless }
+    override fun isSupportedFile(file: VirtualFile) = GodotFileUtil.isGdFile(file)
+    override fun createCommandLine(): GeneralCommandLine {
+        val basePath = GodotCommunityUtil.getGodotProjectBasePath(project)
+        val godotPath = GodotCommunityUtil.getGodotExecutablePath(project)
+        val headlessArg = when (GodotCommunityUtil.getGodotMajorVersion(project)) {
+            GodotMajorVersion.GODOT_4 -> "--headless"
+            else -> "--no-window"
+        }
+        // todo: dap port in the headless Godot may conflict with dap port of the main Godot editor
+        val commandLine = GeneralCommandLine(
+            godotPath.toString(),
+            "--path",
+            "$basePath",
+            "--editor",
+            headlessArg,
+            "--lsp-port",
+            remoteHostPort.toString()
+        )
+        // todo: consider adding dap-port here too? However not sure about it.
+        thisLogger().info("createCommandLine commandLine=$commandLine")
+        return commandLine
+    }
 
-        override fun isSupportedFile(file: VirtualFile) = GodotFileUtil.isGdFile(file)
-        override fun createCommandLine(): GeneralCommandLine {
-            val basePath = GodotCommunityUtil.getGodotProjectBasePath(project)
-            val godotPath = GodotCommunityUtil.getGodotExecutablePath(project)
-            val headlessArg = when (GodotCommunityUtil.getGodotMajorVersion(project)) {
-                GodotMajorVersion.GODOT_4 -> "--headless"
-                else -> "--no-window"
-            }
-            // todo: dap port in the headless Godot may conflict with dap port of the main Godot editor
-            val commandLine = GeneralCommandLine(
-                godotPath.toString(),
-                "--path",
-                "$basePath",
-                "--editor",
-                headlessArg,
-                "--lsp-port",
-                remoteHostPort.toString()
+    override val lspCommunicationChannel: LspCommunicationChannel
+        get() {
+            thisLogger().info("lspCommunicationChannel port=$remoteHostPort, mode=$lspConnectionMode")
+            return LspCommunicationChannel.Socket(
+                remoteHostPort!!,
+                lspConnectionMode == GdLspConnectionMode.StartEditorHeadless
             )
-            // can be solved with https://github.com/godotengine/godot/pull/92336, when it is released
-            // val commandLine = GeneralCommandLine(godotPath, "--path", "$basePath", "--editor", headlessArg, "--lsp-port", remoteHostPort.toString(), "--dap-port", dapPort.toString())
-            thisLogger().info("createCommandLine commandLine=$commandLine")
-            return commandLine
-            // https://github.com/godotengine/godot-proposals/issues/7558#issuecomment-1693765359
         }
 
-        override val lspCommunicationChannel: LspCommunicationChannel
+    override fun getLanguageId(file: VirtualFile) = "gdscript"
+
+    override val clientCapabilities: ClientCapabilities
+        get() = super.clientCapabilities.apply {
+            // RIDER-129495 Allows converting [color] BBCode to <span>
+            general?.markdown = MarkdownCapabilities().apply {
+                parser = "marked"
+                version = "1.1.0"
+                allowedTags = listOf("span")
+            }
+            // RIDER-134419 choosing function from autocomplete options leads to unwanted parentheses
+            // Godot's LSP snippetSupport is for functions with parameters, we have a client handler for the case
+            textDocument = (textDocument ?: TextDocumentClientCapabilities()).apply {
+                completion = (completion ?: CompletionCapabilities()).apply {
+                    completionItem = (completionItem ?: CompletionItemCapabilities()).apply {
+                        snippetSupport = false
+                    }
+                }
+            }
+        }
+
+    override fun createLsp4jClient(handler: LspServerNotificationsHandler): Lsp4jClient {
+        return GodotLsp4jClient(handler, project)
+    }
+
+    override val lspCustomization: LspCustomization = object : LspCustomization() {
+        override val completionCustomizer: LspCompletionCustomizer = GodotLspCompletionSupport()
+        override val hoverCustomizer: LspHoverCustomizer
             get() {
-                thisLogger().info("lspCommunicationChannel port=$remoteHostPort, mode=$lspConnectionMode")
-                return LspCommunicationChannel.Socket(
-                    remoteHostPort!!,
-                    lspConnectionMode == GdLspConnectionMode.StartEditorHeadless
-                )
+                if (GdProjectSettingsState.getInstance(project).state.docProvider != GdDocProviderMode.LSP)
+                    return LspHoverDisabled
+                return super.hoverCustomizer
             }
 
-        override fun getLanguageId(file: VirtualFile) = "gdscript"
+        override val inlayHintCustomizer: LspInlayHintCustomizer = LspInlayHintDisabled
 
-        override val clientCapabilities: ClientCapabilities
-            get() = super.clientCapabilities.apply {
-                // RIDER-129495 Allows converting [color] BBCode to <span>
-                general?.markdown = MarkdownCapabilities().apply {
-                    parser = "marked"
-                    version = "1.1.0"
-                    allowedTags = listOf("span")
+        override val diagnosticsCustomizer: LspDiagnosticsCustomizer = object : LspDiagnosticsSupport() {
+            override fun getHighlightSeverity(diagnostic: Diagnostic): HighlightSeverity? {
+                // RIDER-117554, also fixed in Godot 4.7 https://github.com/godotengine/godot/pull/114185
+                val beforeGodot47 =
+                    GdProjectGodotService.getInstance(project).projectInfoFlow.value?.parsedVersion?.lessThan(4, 7)
+                        ?: false
+                if (diagnostic.message.startsWith("(UNUSED_PARAMETER)") && beforeGodot47) {
+                    return null
                 }
-                // RIDER-134419 choosing function from autocomplete options leads to unwanted parentheses
-                // Godot's LSP snippetSupport is for functions with parameters, we have a client handler for the case
-                textDocument = (textDocument ?: TextDocumentClientCapabilities()).apply {
-                    completion = (completion ?: CompletionCapabilities()).apply {
-                        completionItem = (completionItem ?: CompletionItemCapabilities()).apply {
-                            snippetSupport = false
-                        }
-                    }
-                }
+
+                return super.getHighlightSeverity(diagnostic)
             }
 
-        override fun createLsp4jClient(handler: LspServerNotificationsHandler): Lsp4jClient {
-            return GodotLsp4jClient(handler, project)
-        }
-
-        override val lspCustomization: LspCustomization = object : LspCustomization() {
-            override val completionCustomizer: LspCompletionCustomizer = GodotLspCompletionSupport()
-            override val hoverCustomizer: LspHoverCustomizer
-                get() {
-                    if (GdProjectSettingsState.getInstance(project).state.docProvider != GdDocProviderMode.LSP)
-                        return LspHoverDisabled
-                    return super.hoverCustomizer
+            /*
+            * UNUSED_VARIABLE, UNUSED_LOCAL_CONSTANT, UNUSED_PRIVATE_CLASS_VARIABLE, UNUSED_PARAMETER, UNUSED_SIGNAL
+            * https://github.com/godotengine/godot/blob/1bd7b99182f7e8de4d6b2f089fec5db9392ac6b8/modules/gdscript/gdscript_warning.cpp#L47C8-L47C23
+            */
+            override fun getSpecialHighlightType(diagnostic: Diagnostic): ProblemHighlightType? {
+                if (diagnostic.message.startsWith("(UNUSED_VARIABLE)")
+                    || diagnostic.message.startsWith("(UNUSED_LOCAL_CONSTANT)")
+                    || diagnostic.message.startsWith("(UNUSED_PRIVATE_CLASS_VARIABLE)")
+                    || diagnostic.message.startsWith("(UNUSED_PARAMETER)")
+                    || diagnostic.message.startsWith("(UNUSED_SIGNAL)")
+                ) {
+                    return ProblemHighlightType.LIKE_UNUSED_SYMBOL
                 }
-
-            override val inlayHintCustomizer: LspInlayHintCustomizer = LspInlayHintDisabled
-
-            override val diagnosticsCustomizer: LspDiagnosticsCustomizer = object : LspDiagnosticsSupport() {
-                override fun getHighlightSeverity(diagnostic: Diagnostic): HighlightSeverity? {
-                    // RIDER-117554, also fixed in Godot 4.7 https://github.com/godotengine/godot/pull/114185
-                    val beforeGodot4_7 = GdProjectGodotService.getInstance(project).projectInfoFlow.value?.parsedVersion?.lessThan(4, 7) ?: false
-                    if (diagnostic.message.startsWith("(UNUSED_PARAMETER)") && beforeGodot4_7) {
-                        return null
-                    }
-
-                    return super.getHighlightSeverity(diagnostic)
-                }
-
-                /*
-                UNUSED_VARIABLE, UNUSED_LOCAL_CONSTANT, UNUSED_PRIVATE_CLASS_VARIABLE, UNUSED_PARAMETER, UNUSED_SIGNAL
-                https://github.com/godotengine/godot/blob/1bd7b99182f7e8de4d6b2f089fec5db9392ac6b8/modules/gdscript/gdscript_warning.cpp#L47C8-L47C23
-                 */
-                override fun getSpecialHighlightType(diagnostic: Diagnostic): ProblemHighlightType? {
-                    if (diagnostic.message.startsWith("(UNUSED_VARIABLE)")
-                        || diagnostic.message.startsWith("(UNUSED_LOCAL_CONSTANT)")
-                        || diagnostic.message.startsWith("(UNUSED_PRIVATE_CLASS_VARIABLE)")
-                        || diagnostic.message.startsWith("(UNUSED_PARAMETER)")
-                        || diagnostic.message.startsWith("(UNUSED_SIGNAL)")
-                    ) {
-                        return ProblemHighlightType.LIKE_UNUSED_SYMBOL
-                    }
-                    return super.getSpecialHighlightType(diagnostic)
-                }
+                return super.getSpecialHighlightType(diagnostic)
             }
         }
     }

--- a/gdscript/src/main/kotlin/gdscript/lsp/GodotLspNotConnectedNotificationProvider.kt
+++ b/gdscript/src/main/kotlin/gdscript/lsp/GodotLspNotConnectedNotificationProvider.kt
@@ -15,7 +15,7 @@ import com.intellij.ui.EditorNotifications
 import com.jetbrains.rider.godot.community.actions.StartGodotEditorAction
 import com.jetbrains.rider.godot.community.utils.GodotCommunityUtil
 import com.jetbrains.rider.godot.community.utils.GodotFileUtil
-import common.util.GdScriptProjectLifetimeService
+import com.jetbrains.rider.godot.community.GdScriptProjectLifetimeService
 import gdscript.GdScriptBundle
 import gdscript.settings.GdLspConnectionMode
 import gdscript.settings.GdLspSettingsFlowService

--- a/gdscript/src/main/kotlin/gdscript/lsp/GodotLspNotification.kt
+++ b/gdscript/src/main/kotlin/gdscript/lsp/GodotLspNotification.kt
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 package gdscript.lsp
 
 import com.intellij.notification.Notification
@@ -9,9 +11,13 @@ import com.intellij.openapi.application.EDT
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
+import com.intellij.platform.lsp.api.LspClient
+import com.intellij.platform.lsp.api.LspClientManager
+import com.intellij.platform.lsp.api.LspClientManagerListener
+import com.intellij.platform.lsp.api.LspServerState
 import com.jetbrains.rd.util.lifetime.SequentialLifetimes
+import com.jetbrains.rider.godot.community.GdScriptProjectLifetimeService
 import com.jetbrains.rider.godot.community.actions.StartGodotEditorAction
-import common.util.GdScriptProjectLifetimeService
 import gdscript.GdScriptBundle
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -22,21 +28,36 @@ class GodotLspNotification(val project: Project, private val coroutineScope: Cor
 
     companion object {
         private const val GROUP_ID = "GodotSupportNotificationGroupId"
-        
-        fun getService(project: Project): GodotLspNotification = project.service<GodotLspNotification>()
+
+        fun getService(project: Project): GodotLspNotification = project.service()
     }
 
-    private val pluginLifetime = GdScriptProjectLifetimeService.getLifetime(project)
-    private val nestedLifetimeDef = pluginLifetime.createNested()
-    private val sequentialLifetimes = SequentialLifetimes(nestedLifetimeDef)
+    /**
+     * Tracks the lifetime of the currently visible "non-matching project" warning notification.
+     */
+    private val sessionLifetimes = SequentialLifetimes(GdScriptProjectLifetimeService.getLifetime(project))
+
+    init {
+        LspClientManager.getInstance(project).addListener(
+            object : LspClientManagerListener {
+                override fun serverStateChanged(lspClient: LspClient) {
+                    if (lspClient.providerClass != GodotLspIntegrationProvider::class.java) return
+                    if (lspClient.state == LspServerState.Running) {
+                        // Drop any non-matching-project warning still shown from the previous session.
+                        sessionLifetimes.terminateCurrent()
+                    }
+                }
+            },
+            GdScriptProjectLifetimeService.getInstance(project)
+        )
+    }
 
     /**
-     * Shows a warning notification when LSP attempts to connect to a non-matching project
+     * Shows a warning notification when LSP attempts to connect to a non-matching project.
      */
     fun showNonMatchingProjectWarning() {
         val title = GdScriptBundle.message("notification.title.godot.lsp.warning")
         val content = GdScriptBundle.message("notification.content.lsp.attempted.to.connect.to.non.matching.project")
-        val notificationLifetime = sequentialLifetimes.next()
 
         val notification = Notification(
             GROUP_ID,
@@ -50,14 +71,13 @@ class GodotLspNotification(val project: Project, private val coroutineScope: Cor
             GdScriptBundle.message("action.StartEditorAction.text")) {
             override fun actionPerformed(e: AnActionEvent, notification: Notification) {
                 StartGodotEditorAction.startEditor(project)
-                notificationLifetime.terminate()
             }
         })
 
-        val job = coroutineScope.launch(Dispatchers.EDT) {
+        val notificationLifetime = sessionLifetimes.next().lifetime
+        coroutineScope.launch(Dispatchers.EDT) {
             Notifications.Bus.notify(notification, project)
             notificationLifetime.onTermination { notification.expire() }
         }
-        notificationLifetime.onTermination { job.cancel() }
     }
 }

--- a/gdscript/src/main/kotlin/gdscript/lsp/GodotLspStartOnFocusGainedActivity.kt
+++ b/gdscript/src/main/kotlin/gdscript/lsp/GodotLspStartOnFocusGainedActivity.kt
@@ -8,7 +8,7 @@ import com.intellij.openapi.startup.ProjectActivity
 import com.intellij.openapi.wm.IdeFrame
 import com.jetbrains.rider.godot.community.utils.GodotCommunityUtil
 import com.jetbrains.rider.godot.community.utils.GodotFileUtil
-import common.util.GdScriptProjectLifetimeService
+import com.jetbrains.rider.godot.community.GdScriptProjectLifetimeService
 import gdscript.settings.GdLspConnectionMode
 import gdscript.settings.GdLspSettingsFlowService
 import kotlinx.coroutines.Job

--- a/gdscript/src/main/kotlin/gdscript/lsp/RunningGodotEditorDiscovery.kt
+++ b/gdscript/src/main/kotlin/gdscript/lsp/RunningGodotEditorDiscovery.kt
@@ -1,0 +1,101 @@
+package gdscript.lsp
+
+import com.intellij.openapi.diagnostic.ControlFlowException
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.diagnostic.thisLogger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.nio.file.InvalidPathException
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.jvm.optionals.getOrNull
+
+/**
+ * Detects a running Godot editor for the given Rider project by inspecting OS processes, and returns
+ * the value of a requested `--<port-flag>` argument (e.g. `--lsp-port` or `--dap-port`), if any.
+ * A process matches when its executable looks like Godot, it runs as an editor (`--editor` / `-e`),
+ * it has the requested `--<port-flag> <port>`, and its `--path` exactly equals basePath.
+ *
+ * The point is to connect to an already-running editor for the same project instead of starting a
+ * new one (or using a stale port from settings).
+ *
+ * We match on `--path` rather than working directory because the IntelliJ Platform doesn't expose a
+ * foreign process's working directory, and reading it ourselves (`/proc/<pid>/cwd`, `lsof`) is too
+ * platform-specific. Both our launcher and the Godot project manager always pass `--path`.
+ *
+ * TODO: Consider attempt to connect Godot editor processes without `--path`
+ * and somehow use `gdscript_client/changeWorkspace` notification to verify if it is the correct one
+ */
+object RunningGodotEditorDiscovery {
+    private val LOG = Logger.getInstance(RunningGodotEditorDiscovery::class.java)
+
+    /** Convenience wrapper looking up `--lsp-port` of a running Godot editor for [basePath]. */
+    suspend fun findRunningGodotLspPort(basePath: Path): Int? = findRunningGodotPort(basePath, "--lsp-port")
+
+    /** Convenience wrapper looking up `--dap-port` of a running Godot editor for [basePath]. */
+    suspend fun findRunningGodotDapPort(basePath: Path): Int? = findRunningGodotPort(basePath, "--dap-port")
+
+    /** Parsed information about a Godot process command-line that is relevant for editor discovery. */
+    internal data class GodotProcessArgs(val path: String?, val port: Int?, val isEditor: Boolean)
+
+    /**
+     * Looks up a running Godot editor for [basePath] and returns the value of its [portFlag]
+     * argument (e.g. `--lsp-port`, `--dap-port`), or `null` if no matching editor is found.
+     *
+     * Only processes whose `--path` exactly equals [basePath] are considered; processes without
+     * `--path` are ignored (see class-level TODO).
+     */
+    suspend fun findRunningGodotPort(basePath: Path, portFlag: String): Int? = withContext(Dispatchers.IO) {
+        ProcessHandle.allProcesses().toList().firstNotNullOfOrNull { handle ->
+            try {
+                val info = handle.info()
+                val command = info.command().getOrNull() ?: return@firstNotNullOfOrNull null
+                if (!looksLikeGodotExecutable(command)) return@firstNotNullOfOrNull null
+
+                val args = info.arguments().getOrNull()?.toList() ?: return@firstNotNullOfOrNull null
+                val processArgs = parseGodotArgs(args, portFlag)
+                if (!processArgs.isEditor) return@firstNotNullOfOrNull null
+                if (processArgs.port == null) return@firstNotNullOfOrNull null
+                val pathString = processArgs.path ?: return@firstNotNullOfOrNull null
+                val parsedPath = try { Paths.get(pathString) } catch (_: InvalidPathException) { return@firstNotNullOfOrNull null }
+                if (parsedPath.normalize() != basePath.normalize()) return@firstNotNullOfOrNull null
+                processArgs.port
+            }
+            catch (e: Exception) {
+                if (e is CancellationException || e is ControlFlowException) throw e
+                LOG.debug("Cannot inspect process ${handle.pid()}", e)
+                null
+            }
+        }
+    }
+
+    /**
+     * Parses `--path`, the requested [portFlag], and the editor flag (`--editor` / `-e`).
+     * Godot only accepts the space-separated `--flag value` form (see `main/main.cpp`), so we
+     * don't handle `--flag=value`.
+     */
+    internal fun parseGodotArgs(args: List<String>, portFlag: String): GodotProcessArgs {
+        val isEditor = "--editor" in args || "-e" in args
+        val path = findFlagValue(args, "--path")
+        val port = findFlagValue(args, portFlag)?.toIntOrNull()
+        return GodotProcessArgs(path, port, isEditor)
+    }
+
+    /** Finds a value for a `--flag value` style option, or `null` if missing. */
+    private fun findFlagValue(args: List<String>, flag: String): String? {
+        val index = args.indexOf(flag)
+        if (index < 0) return null
+        return args.getOrNull(index + 1)
+    }
+
+    internal fun looksLikeGodotExecutable(command: String): Boolean {
+        val name = try {
+            Paths.get(command).fileName?.toString()
+        } catch (_: InvalidPathException) {
+            thisLogger().trace("Invalid path: $command")
+            command.substringAfterLast('/').substringAfterLast('\\')
+        } ?: return false
+        return name.startsWith("godot", ignoreCase = true)
+    }
+}

--- a/gdscript/src/main/kotlin/gdscript/statistics/GdProjectUsagesCollector.kt
+++ b/gdscript/src/main/kotlin/gdscript/statistics/GdProjectUsagesCollector.kt
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 package gdscript.statistics
 
 import com.intellij.internal.statistic.beans.MetricEvent
@@ -5,7 +7,7 @@ import com.intellij.internal.statistic.eventLog.EventLogGroup
 import com.intellij.internal.statistic.eventLog.events.EventFields
 import com.intellij.internal.statistic.service.fus.collectors.ProjectUsagesCollector
 import com.intellij.openapi.project.Project
-import gdscript.library.GdProjectGodotService
+import com.jetbrains.rider.godot.community.GdProjectGodotService
 
 class GdProjectUsagesCollector : ProjectUsagesCollector() {
 

--- a/gdscript/src/main/kotlin/tscn/toolWindow/TscnScenePreviewWindow.kt
+++ b/gdscript/src/main/kotlin/tscn/toolWindow/TscnScenePreviewWindow.kt
@@ -22,7 +22,7 @@ import com.intellij.util.BitUtil
 import com.intellij.util.concurrency.AppExecutorUtil
 import com.intellij.util.ui.TimerUtil
 import com.intellij.util.ui.UIUtil
-import common.util.GdScriptProjectLifetimeService
+import com.jetbrains.rider.godot.community.GdScriptProjectLifetimeService
 import gdscript.GdScriptBundle
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.BufferOverflow

--- a/gdscript/src/main/kotlin/tscn/toolWindow/TscnScenePreviewWindowFactory.kt
+++ b/gdscript/src/main/kotlin/tscn/toolWindow/TscnScenePreviewWindowFactory.kt
@@ -5,7 +5,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
 import com.intellij.openapi.wm.ToolWindowManager
-import common.util.GdScriptProjectLifetimeService
+import com.jetbrains.rider.godot.community.GdScriptProjectLifetimeService
 import gdscript.GdScriptBundle
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch


### PR DESCRIPTION
Also dispose notification, when we connect successfully

Fixes https://github.com/JetBrains/godot-support/issues/608