### PR TITLE
Add regression tests for NAN/INF literal type inference (#635)

### DIFF
--- a/gdscript/src/test/kotlin/com/jetbrains/godot/gdscript/inspection/GdTypeHintInspectionTest.kt
+++ b/gdscript/src/test/kotlin/com/jetbrains/godot/gdscript/inspection/GdTypeHintInspectionTest.kt
@@ -57,6 +57,32 @@ class GdTypeHintInspectionTest : BasePlatformTestCase() {
         myFixture.checkResult("var t := true")
     }
 
+    @Test
+    fun testTypeHintInferredQuickFixNanLiteral() {
+        myFixture.configureByText("test.gd", "<caret>var t = NAN")
+        myFixture.doHighlighting()
+        val actions = myFixture.availableIntentions
+        val filtered = actions.filter { it.text.contains("type") || it.text.contains(":=)") }
+        assertSize(2, filtered)
+        assertEquals("Specify variable type [float]", filtered[0].text)
+
+        myFixture.launchAction(filtered[0])
+        myFixture.checkResult("var t: float = NAN")
+    }
+
+    @Test
+    fun testTypeHintInferredQuickFixInfLiteral() {
+        myFixture.configureByText("test.gd", "<caret>var t = INF")
+        myFixture.doHighlighting()
+        val actions = myFixture.availableIntentions
+        val filtered = actions.filter { it.text.contains("type") || it.text.contains(":=)") }
+        assertSize(2, filtered)
+        assertEquals("Specify variable type [float]", filtered[0].text)
+
+        myFixture.launchAction(filtered[0])
+        myFixture.checkResult("var t: float = INF")
+    }
+
     override fun getTestDataPath(): String {
         return getBaseTestDataPath().resolve("testData/gdscript/inspection").pathString
     }

--- a/gdscript/src/test/kotlin/com/jetbrains/godot/gdscript/returntype/ReturnTypeTest.kt
+++ b/gdscript/src/test/kotlin/com/jetbrains/godot/gdscript/returntype/ReturnTypeTest.kt
@@ -28,6 +28,17 @@ class ReturnTypeTest : BasePlatformTestCase() {
         assertEquals("int", var2Declaration.returnType)
     }
 
+    fun testReturnTypesOfNanInfLiterals() {
+        val file = myFixture.configureByFile(getTestName(false) + ".gd")
+
+        val varDeclarations = file.children.filterIsInstance<GdClassVarDeclTl>()
+        val var1Declaration = varDeclarations.first { it.name == "var1" }
+        val var2Declaration = varDeclarations.first { it.name == "var2" }
+
+        assertEquals("float", var1Declaration.returnType)
+        assertEquals("float", var2Declaration.returnType)
+    }
+
     override fun getTestDataPath(): String {
         return getBaseTestDataPath().resolve("testData/gdscript/parser/returnType").pathString
     }

--- a/gdscript/src/test/testData/gdscript/parser/returnType/ReturnTypesOfNanInfLiterals.gd
+++ b/gdscript/src/test/testData/gdscript/parser/returnType/ReturnTypesOfNanInfLiterals.gd
@@ -1,0 +1,2 @@
+var var1 = NAN
+var var2 = INF


### PR DESCRIPTION
Summary
- Adds regression tests for #635 (follow-up to #637):
  - `GdTypeHintInspectionTest`: NAN and INF cases for the "Specify variable type" quick-fix (`GdAddVariableTypeHintFix`), following the existing `launchAction` + `checkResult` pattern, asserts the inspection offers `[float]` and inserts `: float`.
  - `ReturnTypeTest.testReturnTypesOfNanInfLiterals`: asserts both literals infer as `float` at the type-inference level (`PsiGdExprUtil.getReturnType`).
- Verified both directions: before #637 these failed with `[inf]`/`[nan]` (and the quick-fix threw the NPE from the issue), on current master they pass.
- No user-facing behavior changes (tests only).

Notes
- I didn't set `shortTyped` as the neighboring tests do, because as far as I can tell it isn't read anywhere in production code (only declared in `GdProjectState`, written by tests), so it looks like a leftover. Happy to add it back for consistency if preferred.

Checklist for new contributions
- [x] The fix or feature implementation is included in this PR (tests for #635 , the fix itself landed in #637)
- [x] Tests are added/updated as per documentation/contribution/tests.md
  - [x] I ran: ./gradlew test and verified they pass locally
- [ ] Optional: A YouTrack issue is linked